### PR TITLE
feat: add oauth2 credentials

### DIFF
--- a/credentials/ApifyOAuth2Api.credentials.ts
+++ b/credentials/ApifyOAuth2Api.credentials.ts
@@ -9,8 +9,8 @@ export class ApifyOAuth2Api implements ICredentialType {
 
 	displayName = 'Apify OAuth2 API';
 
-  // TODO: documentation URL for Apify OAuth2 API missing
-  documentationUrl = 'https://docs.apify.com/api/v2';
+	// TODO: documentation URL for Apify OAuth2 API missing
+	documentationUrl = 'https://docs.apify.com/api/v2';
 
 	properties: INodeProperties[] = [
 		{

--- a/credentials/ApifyOAuth2Api.credentials.ts
+++ b/credentials/ApifyOAuth2Api.credentials.ts
@@ -1,0 +1,65 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+const scopes = ['profile', 'full_api_access'];
+
+export class ApifyOAuth2Api implements ICredentialType {
+	name = 'apifyOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Apify OAuth2 API';
+
+  // TODO: documentation URL for Apify OAuth2 API missing
+  documentationUrl = 'https://docs.apify.com/api/v2';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'pkce',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://console.apify.com/authorize/oauth',
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://console-backend.apify.com/oauth/apps/token',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'hidden',
+			default: `${scopes.join(' ')}`,
+		},
+		{
+			displayName: 'Auth URI Query Parameters',
+			name: 'authQueryParameters',
+			type: 'hidden',
+			default: '',
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'header',
+		},
+		{
+			displayName: 'Client ID',
+			name: 'clientId',
+			type: 'hidden',
+			default: '',
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'hidden',
+			default: '',
+		},
+	];
+}

--- a/nodes.config.js
+++ b/nodes.config.js
@@ -9,6 +9,12 @@ module.exports = {
 			className: 'ApifyApi',
 			scheme: 'apiKey',
 		},
+		ApifyOAuth2Api: {
+			displayName: 'Apify OAuth2 API',
+			name: 'apifyOAuth2Api',
+			className: 'ApifyOAuth2Api',
+			scheme: 'oauth2',
+		},
 	},
 	nodes: {
 		Apify: {
@@ -58,7 +64,18 @@ module.exports = {
 				{
 					displayName: 'Apify API',
 					name: 'apifyApi',
-					required: true,
+					required: false,
+					show: {
+						authentication: ['apiKey'],
+					},
+				},
+				{
+					displayName: 'Apify OAuth2 API',
+					name: 'apifyOAuth2Api',
+					required: false,
+					show: {
+						authentication: ['oauth2'],
+					},
 				},
 			],
 		},

--- a/nodes/Apify/Apify.node.ts
+++ b/nodes/Apify/Apify.node.ts
@@ -21,7 +21,22 @@ export class Apify implements INodeType {
 			{
 				displayName: 'Apify connection',
 				name: 'apifyApi',
-				required: true,
+				required: false,
+				displayOptions: {
+					show: {
+						authentication: ['apifyApi'],
+					},
+				},
+			},
+			{
+				displayName: 'Apify OAuth2 API',
+				name: 'apifyOAuth2Api',
+				required: false,
+				displayOptions: {
+					show: {
+						authentication: ['apifyOAuth2Api'],
+					},
+				},
 			},
 		],
 
@@ -29,6 +44,7 @@ export class Apify implements INodeType {
 			headers: {
 				Accept: 'application/json',
 				'Content-Type': 'application/json',
+				'x-apify-integration-platform': 'n8n',
 			},
 			baseURL: 'https://api.apify.com',
 		},

--- a/nodes/Apify/Apify.properties.ts
+++ b/nodes/Apify/Apify.properties.ts
@@ -1,4 +1,24 @@
 import { INodeProperties } from 'n8n-workflow';
 import { properties as resources } from './resources';
 
-export const properties: INodeProperties[] = [...resources];
+const authenticationProperties: INodeProperties[] = [
+	{
+		displayName: 'Authentication',
+		name: 'authentication',
+		type: 'options',
+		options: [
+			{
+				name: 'API Key',
+				value: 'apifyApi',
+			},
+			{
+				name: 'OAuth2',
+				value: 'apifyOAuth2Api',
+			},
+		],
+		default: 'apifyApi',
+		description: 'Choose which authentication method to use',
+	},
+];
+
+export const properties: INodeProperties[] = [...resources, ...authenticationProperties];

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 	"n8n": {
 		"n8nNodesApiVersion": 1,
 		"credentials": [
-			"dist/credentials/ApifyApi.credentials.js"
+			"dist/credentials/ApifyApi.credentials.js",
+			"dist/credentials/ApifyOAuth2Api.credentials.js"
 		],
 		"nodes": [
 			"dist/nodes/Apify/Apify.node.js"


### PR DESCRIPTION
This PR adds the oAuth2 flow to n8n node. 
Also added the` x-apify-integration-platform` header for tracking.

To test this locally it's necessary to provide the overwrite for the `Client ID` and `Client Secret` fields. 
To provide the overwrite it's necessary to inject the overwrite: 

```
export CREDENTIALS_OVERWRITE_DATA='{
 "apifyOAuth2Api": 
 {
  "clientId": "CLIENT_ID",
  "clientSecret":"CLIENT_SECRET"
 }
}'
pnpm build
n8n start 
```

