### PR TITLE
fix: handle store-record as buffer

### DIFF
--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -1,1 +1,2 @@
 export const WEB_CONTENT_SCRAPER_ACTOR_ID = 'aYG0l9s7dbB7j3gbS';
+export const APIFY_API_URL = 'https://api.apify.com';


### PR DESCRIPTION
- reverted back to this PR https://github.com/apify/n8n-nodes-apify/pull/6/files#diff-7134f19bd67de38be5be90ebed6339f38d7800d196e0f92484054ced4a70dab1
- with an upgrade that it can now handle JSON and text (such as text/html)
 - json and text can be now part of the workflow and used as values in next operations