### PR TITLE
test: create trigger-node tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,7 @@ module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
 	roots: ['<rootDir>/nodes', '<rootDir>/credentials'],
-	// testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-	testMatch: ['**/ApifyTrigger.node.spec.ts'],
+	testMatch: ['**/__tests__/**/?(*.)+(spec).ts'],
 	transform: {
 		'^.+\\.ts$': 'ts-jest',
 	},

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/nodes', '<rootDir>/credentials'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  moduleFileExtensions: ['ts', 'js', 'json'],
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>/nodes', '<rootDir>/credentials'],
+	// testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+	testMatch: ['**/ApifyTrigger.node.spec.ts'],
+	transform: {
+		'^.+\\.ts$': 'ts-jest',
+	},
+	moduleFileExtensions: ['ts', 'js', 'json'],
 };

--- a/nodes/Apify/ApifyTrigger.node.ts
+++ b/nodes/Apify/ApifyTrigger.node.ts
@@ -204,6 +204,7 @@ export class ApifyTrigger implements INodeType {
 				webhookData.webhookId = id;
 				return true;
 			},
+
 			async delete(this: IHookFunctions): Promise<boolean> {
 				const webhookData = this.getWorkflowStaticData('node');
 				if (!webhookData.webhookId) return false;

--- a/nodes/Apify/__tests__/ApifyTrigger.node.spec.ts
+++ b/nodes/Apify/__tests__/ApifyTrigger.node.spec.ts
@@ -34,8 +34,6 @@ describe('Apify Trigger Node', () => {
 		});
 
 		it('should return true in checkExists webhook method since there is a webhook created with the same url', async () => {
-			// webhook url is 'http://localhost:5678/2726981e-4e01-461f-a548-1f467e997400/webhook'
-
 			const scope = nock('https://api.apify.com')
 				.get('/v2/webhooks')
 				.reply(200, fixtures.getActorWebhookResult());

--- a/nodes/Apify/__tests__/ApifyTrigger.node.spec.ts
+++ b/nodes/Apify/__tests__/ApifyTrigger.node.spec.ts
@@ -1,0 +1,122 @@
+import nock from 'nock';
+
+import apifyTriggerWorkflow from './workflows/webhook/webhook.workflow.json';
+import { executeWorkflow } from './utils/executeWorkflow';
+import { CredentialsHelper } from './utils/credentialHelper';
+import { runWebhookMethod } from './utils/runWebhookMethod';
+import * as fixtures from './utils/fixtures';
+
+describe('Apify Trigger Node', () => {
+	describe('checkExists', () => {
+		it('should return false in checkExists webhook method since there is any webhook created', async () => {
+			const scope = nock('https://api.apify.com')
+				.get('/v2/webhooks')
+				.reply(200, {
+					data: { items: [] },
+				});
+
+			const credentialsHelper = new CredentialsHelper({
+				apifyApi: {
+					apiToken: 'test-token',
+					baseUrl: 'https://api.apify.com',
+				},
+			});
+
+			const { workflow, additionalData } = await executeWorkflow({
+				credentialsHelper,
+				workflow: apifyTriggerWorkflow,
+			});
+
+			const result = await runWebhookMethod(workflow, additionalData, 'checkExists');
+			expect(result).toEqual(false);
+
+			expect(scope.isDone()).toBe(true);
+		});
+
+		it('should return true in checkExists webhook method since there is a webhook created with the same url', async () => {
+			// webhook url is 'http://localhost:5678/2726981e-4e01-461f-a548-1f467e997400/webhook'
+
+			const scope = nock('https://api.apify.com')
+				.get('/v2/webhooks')
+				.reply(200, fixtures.getActorWebhookResult());
+
+			const credentialsHelper = new CredentialsHelper({
+				apifyApi: {
+					apiToken: 'test-token',
+					baseUrl: 'https://api.apify.com',
+				},
+			});
+
+			const { workflow, additionalData } = await executeWorkflow({
+				credentialsHelper,
+				workflow: apifyTriggerWorkflow,
+			});
+
+			const result = await runWebhookMethod(workflow, additionalData, 'checkExists');
+			expect(result).toBe(true);
+
+			const node = Object.values(workflow.nodes)[0];
+			expect(node.webhookId).toEqual('2726981e-4e01-461f-a548-1f467e997400');
+
+			expect(scope.isDone()).toBe(true);
+		});
+	});
+
+	describe('create', () => {
+		it('should create the webhook', async () => {
+			const scope = nock('https://api.apify.com')
+				.post('/v2/webhooks')
+				.reply(201, fixtures.getCreateWebhookResult());
+
+			const credentialsHelper = new CredentialsHelper({
+				apifyApi: {
+					apiToken: 'test-token',
+					baseUrl: 'https://api.apify.com',
+				},
+			});
+			const { workflow, additionalData } = await executeWorkflow({
+				credentialsHelper,
+				workflow: apifyTriggerWorkflow,
+			});
+
+			const result = await runWebhookMethod(workflow, additionalData, 'create');
+			expect(result).toBe(true);
+
+			const node = Object.values(workflow.nodes)[0];
+			const webhookData = workflow.getStaticData('node', node);
+			expect(webhookData.webhookId).toEqual(fixtures.getCreateWebhookResult().data.id);
+
+			expect(scope.isDone()).toBe(true);
+		});
+	});
+
+	describe('delete', () => {
+		it('should delete the webhook', async () => {
+			const webhookId = fixtures.getCreateWebhookResult().data.id;
+
+			const scope = nock('https://api.apify.com').delete(`/v2/webhooks/${webhookId}`).reply(204);
+
+			const credentialsHelper = new CredentialsHelper({
+				apifyApi: {
+					apiToken: 'test-token',
+					baseUrl: 'https://api.apify.com',
+				},
+			});
+			const { workflow, additionalData } = await executeWorkflow({
+				credentialsHelper,
+				workflow: apifyTriggerWorkflow,
+			});
+
+			const node = Object.values(workflow.nodes)[0];
+			const webhookData = workflow.getStaticData('node', node);
+			webhookData.webhookId = webhookId;
+
+			const result = await runWebhookMethod(workflow, additionalData, 'delete');
+			expect(result).toBe(true);
+
+			expect(workflow.getStaticData('node', node)).toEqual({});
+
+			expect(scope.isDone()).toBe(true);
+		});
+	});
+});

--- a/nodes/Apify/__tests__/utils/fixtures.ts
+++ b/nodes/Apify/__tests__/utils/fixtures.ts
@@ -1612,3 +1612,115 @@ export const getKeyValueStoreRecordResult = () => {
 		},
 	];
 };
+
+export const getActorWebhookResult = () => {
+	return {
+		data: {
+			total: 2,
+			count: 2,
+			offset: 0,
+			limit: 1000,
+			desc: false,
+			items: [
+				{
+					id: 'OYb2eUWmLC3UcIMMQ',
+					createdAt: '2025-06-12T20:17:07.105Z',
+					modifiedAt: '2025-06-12T20:17:07.105Z',
+					userId: 'A9zwKYff2yyRmaqc9',
+					isEnabled: true,
+					isAdHoc: false,
+					eventTypes: [
+						'ACTOR.RUN.SUCCEEDED',
+						'ACTOR.RUN.FAILED',
+						'ACTOR.RUN.TIMED_OUT',
+						'ACTOR.RUN.ABORTED',
+					],
+					condition: {
+						actorId: 'nFJndFXA5zjCTuudP',
+					},
+					ignoreSslErrors: false,
+					doNotRetry: false,
+					requestUrl:
+						'https://fcaa-193-165-0-33.ngrok-free.app/webhook/8856069e-bd4b-45b2-8042-5f18b9547804/webhook',
+					payloadTemplate:
+						'{\n    "userId": {{userId}},\n    "createdAt": {{createdAt}},\n    "eventType": {{eventType}},\n    "eventData": {{eventData}},\n    "resource": {{resource}}\n}',
+					lastDispatch: {
+						status: 'SUCCEEDED',
+						finishedAt: '2025-06-17T08:58:14.804Z',
+						removedAt: null,
+					},
+					stats: {
+						totalDispatches: 8,
+					},
+					actionType: 'HTTP_REQUEST',
+					shouldInterpolateStrings: false,
+				},
+				{
+					id: 'WmLC3UcIMMQOYb2eU',
+					createdAt: '2025-06-12T20:17:07.105Z',
+					modifiedAt: '2025-06-12T20:17:07.105Z',
+					userId: 'A9zwKYff2yyRmaqc9',
+					isEnabled: true,
+					isAdHoc: false,
+					eventTypes: [
+						'ACTOR.RUN.SUCCEEDED',
+						'ACTOR.RUN.FAILED',
+						'ACTOR.RUN.TIMED_OUT',
+						'ACTOR.RUN.ABORTED',
+					],
+					condition: {
+						actorId: 'nFJndFXA5zjCTuudP',
+					},
+					ignoreSslErrors: false,
+					doNotRetry: false,
+					// this URL is the same as the one in the webhook workflow - change with care
+					requestUrl: 'http://localhost:5678/2726981e-4e01-461f-a548-1f467e997400/webhook',
+					payloadTemplate:
+						'{\n    "userId": {{userId}},\n    "createdAt": {{createdAt}},\n    "eventType": {{eventType}},\n    "eventData": {{eventData}},\n    "resource": {{resource}}\n}',
+					lastDispatch: {
+						status: 'SUCCEEDED',
+						finishedAt: '2025-06-17T08:58:14.804Z',
+						removedAt: null,
+					},
+					stats: {
+						totalDispatches: 8,
+					},
+					actionType: 'HTTP_REQUEST',
+					shouldInterpolateStrings: false,
+				},
+			],
+		},
+	};
+};
+
+export const getCreateWebhookResult = () => {
+	return {
+		data: {
+			id: 'UcIMMQOYb2eWmLC3U',
+			createdAt: '2025-06-12T20:17:07.105Z',
+			modifiedAt: '2025-06-12T20:17:07.105Z',
+			userId: 'A9zwKYff2yyRmaqc9',
+			isEnabled: true,
+			isAdHoc: false,
+			eventTypes: [
+				'ACTOR.RUN.SUCCEEDED',
+				'ACTOR.RUN.FAILED',
+				'ACTOR.RUN.TIMED_OUT',
+				'ACTOR.RUN.ABORTED',
+			],
+			condition: {
+				actorId: 'nFJndFXA5zjCTuudP',
+			},
+			ignoreSslErrors: false,
+			doNotRetry: false,
+			requestUrl: 'http://localhost:5678/2f9d9edc-fada-47f5-b452-768dd81027cf/webhook',
+			payloadTemplate:
+				'{\n    "userId": {{userId}},\n    "createdAt": {{createdAt}},\n    "eventType": {{eventType}},\n    "eventData": {{eventData}},\n    "resource": {{resource}}\n}',
+			stats: {
+				totalDispatches: 0,
+			},
+			actionType: 'HTTP_REQUEST',
+			shouldInterpolateStrings: false,
+		},
+	};
+};

--- a/nodes/Apify/__tests__/utils/nodeTypesClass.ts
+++ b/nodes/Apify/__tests__/utils/nodeTypesClass.ts
@@ -7,6 +7,7 @@ import {
 	NodeHelpers,
 } from 'n8n-workflow';
 import { Apify } from '../../Apify.node';
+import { ApifyTrigger } from '../../ApifyTrigger.node';
 
 export class NodeTypesClass implements INodeTypes {
 	nodeTypes: INodeTypeData = {};
@@ -42,6 +43,6 @@ export class NodeTypesClass implements INodeTypes {
 const nodeTypes = new NodeTypesClass();
 
 nodeTypes.addNode('n8n-nodes-apify.apify', new Apify());
-// TODO: add ApifyTrigger
+nodeTypes.addNode('n8n-nodes-apify.apifyTrigger', new ApifyTrigger());
 
 export { nodeTypes };

--- a/nodes/Apify/__tests__/utils/runWebhookMethod.ts
+++ b/nodes/Apify/__tests__/utils/runWebhookMethod.ts
@@ -22,10 +22,6 @@ export const runWebhookMethod = async (
 		additionalData,
 	);
 
-	// const nodesKeys = Object.keys(workflow.nodes);
-
-	// const node = workflow.nodes[nodesKeys[0]];
-
 	const webhookDescription: IWebhookDescription = {
 		name: 'default',
 		httpMethod: 'POST',
@@ -42,45 +38,20 @@ export const runWebhookMethod = async (
 		workflowExecuteAdditionalData: additionalData,
 	};
 
-	// const result = await workflow.runWebhookMethod(
-	//   method,
-	//   webhookNode,
-	//   NodeExecuteFunctions,
-	//   'manual',
-	//   'manual',
-	//   true,
-	// );
-
-	try {
-		// const result = await (
-		// 	workflow as unknown as Record<string, any> & {
-		// 		runWebhookMethod: (
-		// 			method: WebhookSetupMethodNames,
-		// 			webhookData: IWebhookData,
-		// 			nodeExecuteFunctions: INodeExecuteFunctions,
-		// 			mode: WorkflowExecuteMode,
-		// 			activation: WorkflowActivateMode,
-		// 			isTest?: boolean,
-		// 		) => Promise<boolean | undefined>;
-		// 	}
-		// ).runWebhookMethod(webhookData, node, additionalData, NodeExecuteFunctions, 'manual');
-
-		const result = await (
-			workflow as unknown as Record<string, any> & {
-				runWebhookMethod: (
-					method: WebhookSetupMethodNames,
-					webhookData: IWebhookData,
-					nodeExecuteFunctions: INodeExecuteFunctions,
-					mode: WorkflowExecuteMode,
-					activation: WorkflowActivateMode,
-					isTest?: boolean,
-				) => Promise<boolean | undefined>;
-			}
-		).runWebhookMethod(method, webhookData, NodeExecuteFunctions, 'manual', 'manual', true);
-
-		return result;
-	} catch (error) {
-		console.error(error);
-		throw error;
-	}
+	/*
+	 * Override runWebhookMethod which is a private method of the workflow
+	 * but is needed for the tests.
+	 */
+	return (
+		workflow as unknown as Record<string, any> & {
+			runWebhookMethod: (
+				method: WebhookSetupMethodNames,
+				webhookData: IWebhookData,
+				nodeExecuteFunctions: INodeExecuteFunctions,
+				mode: WorkflowExecuteMode,
+				activation: WorkflowActivateMode,
+				isTest?: boolean,
+			) => Promise<boolean | undefined>;
+		}
+	).runWebhookMethod(method, webhookData, NodeExecuteFunctions, 'manual', 'manual', true);
 };

--- a/nodes/Apify/__tests__/utils/runWebhookMethod.ts
+++ b/nodes/Apify/__tests__/utils/runWebhookMethod.ts
@@ -4,11 +4,12 @@ import {
 	WebhookSetupMethodNames,
 	Workflow,
 	IWebhookData,
-	IHttpRequestMethods,
 	IWebhookDescription,
-	INode,
 } from 'n8n-workflow';
 import { NodeExecuteFunctions } from 'n8n-core';
+import { INodeExecuteFunctions } from 'n8n-workflow';
+import { WorkflowExecuteMode } from 'n8n-workflow';
+import { WorkflowActivateMode } from 'n8n-workflow';
 
 export const runWebhookMethod = async (
 	workflow: Workflow,
@@ -21,28 +22,65 @@ export const runWebhookMethod = async (
 		additionalData,
 	);
 
+	// const nodesKeys = Object.keys(workflow.nodes);
+
+	// const node = workflow.nodes[nodesKeys[0]];
+
 	const webhookDescription: IWebhookDescription = {
 		name: 'default',
-		httpMethod: method as IHttpRequestMethods,
-		path: '/webhook',
+		httpMethod: 'POST',
+		responseMode: 'onReceived',
+		path: 'webhook',
 	};
 
 	const webhookData: IWebhookData = {
-		httpMethod: method as IHttpRequestMethods,
-		node: webhookNode.webhookId || 'test',
-		path: '/webhook',
+		httpMethod: 'POST',
+		node: webhookNode.node,
+		path: 'webhook',
 		webhookDescription,
 		workflowId: workflow.id,
 		workflowExecuteAdditionalData: additionalData,
 	};
 
-	const result = await workflow.runWebhook(
-		webhookData,
-		webhookNode as unknown as INode,
-		additionalData,
-		NodeExecuteFunctions,
-		'manual',
-	);
+	// const result = await workflow.runWebhookMethod(
+	//   method,
+	//   webhookNode,
+	//   NodeExecuteFunctions,
+	//   'manual',
+	//   'manual',
+	//   true,
+	// );
 
-	return result;
+	try {
+		// const result = await (
+		// 	workflow as unknown as Record<string, any> & {
+		// 		runWebhookMethod: (
+		// 			method: WebhookSetupMethodNames,
+		// 			webhookData: IWebhookData,
+		// 			nodeExecuteFunctions: INodeExecuteFunctions,
+		// 			mode: WorkflowExecuteMode,
+		// 			activation: WorkflowActivateMode,
+		// 			isTest?: boolean,
+		// 		) => Promise<boolean | undefined>;
+		// 	}
+		// ).runWebhookMethod(webhookData, node, additionalData, NodeExecuteFunctions, 'manual');
+
+		const result = await (
+			workflow as unknown as Record<string, any> & {
+				runWebhookMethod: (
+					method: WebhookSetupMethodNames,
+					webhookData: IWebhookData,
+					nodeExecuteFunctions: INodeExecuteFunctions,
+					mode: WorkflowExecuteMode,
+					activation: WorkflowActivateMode,
+					isTest?: boolean,
+				) => Promise<boolean | undefined>;
+			}
+		).runWebhookMethod(method, webhookData, NodeExecuteFunctions, 'manual', 'manual', true);
+
+		return result;
+	} catch (error) {
+		console.error(error);
+		throw error;
+	}
 };

--- a/nodes/Apify/__tests__/workflows/webhook/webhook.workflow.json
+++ b/nodes/Apify/__tests__/workflows/webhook/webhook.workflow.json
@@ -1,0 +1,41 @@
+{
+	"name": "Webhook Workflow",
+	"nodes": [
+		{
+			"parameters": {
+				"actorId": {
+					"__rl": true,
+					"value": "nFJndFXA5zjCTuudP",
+					"mode": "list",
+					"cachedResultName": "Google Search Results Scraper",
+					"cachedResultUrl": "https://console.com/actors/nFJndFXA5zjCTuudP/input"
+				}
+			},
+			"id": "498adf8f-f3a2-4a54-a268-699254e71221",
+			"name": "Apify Trigger",
+			"type": "n8n-nodes-apify.apifyTrigger",
+			"typeVersion": 1,
+			"position": [1820, 580],
+			"webhookId": "2726981e-4e01-461f-a548-1f467e997400",
+			"credentials": {
+				"apifyApi": {
+					"id": "dJAynKkN2pRqy3Ko",
+					"name": "Apify account"
+				}
+			}
+		}
+	],
+	"pinData": {},
+	"connections": {},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "e3f6ba0a-56cf-4d23-bdf2-0718cad2b0dd",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "3f65ba173ae28613be507e94c0a98de4375527c55e31b7fc173a4edee4e2ded3"
+	},
+	"id": "OFLCq8UoIVInQv2Y",
+	"tags": []
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"lintfix": "eslint nodes credentials package.json --fix",
 		"prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json",
 		"merge:api": "npx openapi-merge-cli --config ./openapi.config.json",
-		"test": "jest --testMatch '**/*.spec.*'"
+		"test": "WEBHOOK_URL=https://localhost:5678 jest --config jest.config.js"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION
- added tests for trigger nodes and its main methods: `checkExists`, `create` and `delete`
- fixed get-run operation (discrepancy in operation name value from https://github.com/apify/n8n-nodes-apify/pull/19/files#diff-c456dfaa467ae9b35c9aa8dc573f322d06d80afe102e65a4385ca42cca5a231b)