### PR TITLE
fix: set extract-value for URLs

### DIFF
--- a/nodes/Apify/resources/actor-runs/get-run/execute.ts
+++ b/nodes/Apify/resources/actor-runs/get-run/execute.ts
@@ -7,7 +7,9 @@ import {
 import { apiRequest } from '../../../resources/genericFunctions';
 
 export async function getRun(this: IExecuteFunctions, i: number): Promise<INodeExecutionData> {
-	const runId = this.getNodeParameter('runId', i) as { value: string };
+	const runId = this.getNodeParameter('runId', i, undefined, {
+		extractValue: true,
+	}) as string;
 
 	if (!runId) {
 		throw new NodeOperationError(this, 'Run ID is required');
@@ -16,12 +18,19 @@ export async function getRun(this: IExecuteFunctions, i: number): Promise<INodeE
 	try {
 		const run = await apiRequest.call(this, {
 			method: 'GET',
-			uri: `/v2/actor-runs/${runId.value}`,
+			uri: `/v2/actor-runs/${runId}`,
 		});
 
 		if (!run) {
 			throw new NodeApiError(this.getNode(), {
-				message: `Run ${runId.value} not found`,
+				message: `Run ${runId} not found`,
+			});
+		}
+
+		if (run.error) {
+			throw new NodeApiError(this.getNode(), {
+				message: run.error.message,
+				type: run.error.type,
 			});
 		}
 

--- a/nodes/Apify/resources/actor-tasks/run-task/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/execute.ts
@@ -7,7 +7,9 @@ import {
 import { apiRequest } from '../../../resources/genericFunctions';
 
 export async function runTask(this: IExecuteFunctions, i: number): Promise<INodeExecutionData> {
-	const actorTaskId = this.getNodeParameter('actorTaskId', i) as { value: string };
+	const actorTaskId = this.getNodeParameter('actorTaskId', i, undefined, {
+		extractValue: true,
+	}) as string;
 	const input = this.getNodeParameter('input', i, {}) as object;
 	const waitForFinish = this.getNodeParameter('waitForFinish', i, null) as number | null;
 	const timeout = this.getNodeParameter('timeout', i, null) as number | null;
@@ -27,14 +29,14 @@ export async function runTask(this: IExecuteFunctions, i: number): Promise<INode
 	try {
 		const run = await apiRequest.call(this, {
 			method: 'POST',
-			uri: `/v2/actor-tasks/${actorTaskId.value}/runs`,
+			uri: `/v2/actor-tasks/${actorTaskId}/runs`,
 			body: input,
 			qs,
 		});
 
 		if (!run) {
 			throw new NodeApiError(this.getNode(), {
-				message: `Task run for ${actorTaskId.value} not found`,
+				message: `Task run for ${actorTaskId} not found`,
 			});
 		}
 

--- a/nodes/Apify/resources/actorResourceLocator.ts
+++ b/nodes/Apify/resources/actorResourceLocator.ts
@@ -22,14 +22,14 @@ const resourceLocatorProperty: INodeProperties = {
 			displayName: 'By URL',
 			name: 'url',
 			type: 'string',
-			// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input
 			placeholder: 'https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input',
 			validation: [
 				{
 					type: 'regex',
 					properties: {
 						// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input
-						regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)',
+						// https://console.apify.com/actors/AtBpiepuIUNs2k2ku
+						regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)(/input)?',
 						errorMessage: 'Not a valid Actor URL',
 					},
 				},
@@ -37,7 +37,8 @@ const resourceLocatorProperty: INodeProperties = {
 			extractValue: {
 				type: 'regex',
 				// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input -> AtBpiepuIUNs2k2ku
-				regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)',
+				// https://console.apify.com/actors/AtBpiepuIUNs2k2ku -> AtBpiepuIUNs2k2ku
+				regex: `https://console.apify.com/actors/([a-zA-Z0-9]+)`,
 			},
 		},
 		{

--- a/nodes/Apify/resources/actorTaskResourceLocator.ts
+++ b/nodes/Apify/resources/actorTaskResourceLocator.ts
@@ -22,14 +22,14 @@ const resourceLocatorProperty: INodeProperties = {
 			displayName: 'By URL',
 			name: 'url',
 			type: 'string',
-			// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input
 			placeholder: 'https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input',
 			validation: [
 				{
 					type: 'regex',
 					properties: {
 						// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input
-						regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+)',
+						// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY
+						regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+)(/input)?',
 						errorMessage: 'Not a valid Apify Actor Task URL',
 					},
 				},
@@ -37,6 +37,7 @@ const resourceLocatorProperty: INodeProperties = {
 			extractValue: {
 				type: 'regex',
 				// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input -> WAtmhr6rhfBnwqKDY
+				// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY -> WAtmhr6rhfBnwqKDY
 				regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+)',
 			},
 		},

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -72,10 +72,9 @@ limit specified in the default run configuration for the Actor.`,
 		},
 	},
 	{
-		displayName: 'Build',
+		displayName: 'Build Tag',
 		name: 'build',
-		description: `Specifies the Actor build to run. It can be either a build tag or build
-number. By default, the run uses the build specified in the default run
+		description: `Specifies the Actor build tag to run. By default, the run uses the build specified in the default run
 configuration for the Actor (typically \`latest\`).`,
 		default: '',
 		type: 'string',

--- a/nodes/Apify/resources/runResourceLocator.ts
+++ b/nodes/Apify/resources/runResourceLocator.ts
@@ -22,22 +22,22 @@ const resourceLocatorProperty: INodeProperties = {
 			displayName: 'By URL',
 			name: 'url',
 			type: 'string',
-			// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/runs/RDfcScrqIYHW0jfNF#log
-			placeholder: 'https://console.apify.com/actors/AtBpiepuIUNs2k2ku/runs/RDfcScrqIYHW0jfNF#log',
+			placeholder: 'https://console.apify.com/actors/runs/RDfcScrqIYHW0jfNF#output',
 			validation: [
 				{
 					type: 'regex',
 					properties: {
-						// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/runs/RDfcScrqIYHW0jfNF#log
-						regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)/runs/([a-zA-Z0-9]+)',
+						// https://console.apify.com/actors/runs/RDfcScrqIYHW0jfNF#output
+						regex:
+							'https://console.apify.com/actors(/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+)(#(output|log))?',
 						errorMessage: 'Not a valid Apify Actor Run URL',
 					},
 				},
 			],
 			extractValue: {
 				type: 'regex',
-				// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/runs/RDfcScrqIYHW0jfNF#log -> RDfcScrqIYHW0jfNF
-				regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)/runs/([a-zA-Z0-9]+)',
+				// https://console.apify.com/actors/runs/RDfcScrqIYHW0jfNF#output -> RDfcScrqIYHW0jfNF
+				regex: 'https://console.apify.com/actors(?:/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+)',
 			},
 		},
 		{
@@ -81,6 +81,7 @@ export async function listRuns(this: ILoadOptionsFunctions): Promise<INodeListSe
 		qs: {
 			limit: 100,
 			offset: 0,
+			desc: 1,
 		},
 	});
 


### PR DESCRIPTION
- fixed regex for run-task, run-actor and get-run
- changed the input name and description for run-actor's `build` field to accept only build tag
 - the reason it works for run-task is because run-actor fetches default input based on passed build tag