### PR TITLE
feat: add search in actor dropdown

### DIFF
--- a/nodes/Apify/resources/actorResourceLocator.ts
+++ b/nodes/Apify/resources/actorResourceLocator.ts
@@ -127,7 +127,7 @@ export async function listActors(
 		method: 'GET',
 		uri: '/v2/acts',
 		qs: {
-			limit: 200,
+			limit: 1000,
 			offset: 0,
 		},
 	});

--- a/nodes/Apify/resources/actorResourceLocator.ts
+++ b/nodes/Apify/resources/actorResourceLocator.ts
@@ -15,7 +15,7 @@ const resourceLocatorProperty: INodeProperties = {
 			typeOptions: {
 				searchListMethod: 'listActors',
 				searchFilterRequired: false,
-				searchable: false,
+				searchable: true,
 			},
 		},
 		{
@@ -108,7 +108,10 @@ export function overrideActorProperties(properties: INodeProperties[]): INodePro
 	return result;
 }
 
-export async function listActors(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
+export async function listActors(
+	this: ILoadOptionsFunctions,
+	searchTerm?: string,
+): Promise<INodeListSearchResult> {
 	const actorSource = this.getNodeParameter('actorSource', 'recentlyUsed') as string;
 
 	const mapToN8nResult = (actor: any) => ({
@@ -130,6 +133,15 @@ export async function listActors(this: ILoadOptionsFunctions): Promise<INodeList
 	});
 
 	if (actorSource === 'recentlyUsed') {
+		if (searchTerm) {
+			const regex = new RegExp(searchTerm, 'i');
+			const filteredActors = recentActors.filter(
+				(actor: any) => regex.test(actor.title || '') || regex.test(actor.name || ''),
+			);
+			return {
+				results: filteredActors.map(mapToN8nResult),
+			};
+		}
 		return {
 			results: recentActors.map(mapToN8nResult),
 		};
@@ -143,6 +155,7 @@ export async function listActors(this: ILoadOptionsFunctions): Promise<INodeList
 		qs: {
 			limit: 200,
 			offset: 0,
+			search: searchTerm,
 		},
 	});
 

--- a/nodes/Apify/resources/actorTaskResourceLocator.ts
+++ b/nodes/Apify/resources/actorTaskResourceLocator.ts
@@ -75,7 +75,10 @@ export function overrideActorTaskProperties(properties: INodeProperties[]) {
 	});
 }
 
-export async function listActorTasks(this: ILoadOptionsFunctions): Promise<INodeListSearchResult> {
+export async function listActorTasks(
+	this: ILoadOptionsFunctions,
+	searchTerm?: string,
+): Promise<INodeListSearchResult> {
 	const searchResults = await apiRequestAllItems.call(this, {
 		method: 'GET',
 		uri: '/v2/actor-tasks',
@@ -85,11 +88,18 @@ export async function listActorTasks(this: ILoadOptionsFunctions): Promise<INode
 		},
 	});
 
-	const { data } = searchResults;
-	const { items } = data;
+	const {
+		data: { items },
+	} = searchResults;
+
+	let filteredItems = [...items];
+	if (searchTerm) {
+		const regex = new RegExp(searchTerm, 'i');
+		filteredItems = items.filter((b: any) => regex.test(b.title || '') || regex.test(b.name || ''));
+	}
 
 	return {
-		results: items.map((b: any) => ({
+		results: filteredItems.map((b: any) => ({
 			name: b.title || b.name,
 			value: b.id,
 			url: `https://console.apify.com/actors/tasks/${b.id}/input`,

--- a/nodes/Apify/resources/actorTaskResourceLocator.ts
+++ b/nodes/Apify/resources/actorTaskResourceLocator.ts
@@ -15,7 +15,7 @@ const resourceLocatorProperty: INodeProperties = {
 			typeOptions: {
 				searchListMethod: 'listActorTasks',
 				searchFilterRequired: false,
-				searchable: false,
+				searchable: true,
 			},
 		},
 		{


### PR DESCRIPTION
- cannot add test for the search feature since, the workflow (the JSON file) does not persist the search value, it's just an ephemeral value
- the search works different for recent actors vs actors from store:
  - recent actors: filters the already fetched result from apify using case-insensitive RegEx
  - store actors: the search-term is passed and query-parameter for fetching from apify API
- the search for tasks -> works the same way as recent actors