### PR TITLE
fix: replace get-last-run status input with dropdown

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -131,6 +131,7 @@ describe('Apify Node', () => {
 
 				const scope = nock('https://api.apify.com')
 					.get('/v2/acts/nFJndFXA5zjCTuudP/runs/last')
+					.query({ status: 'ABORTED' })
 					.reply(200, mockLastRun);
 
 				const getLastRunWorkflow = require('./workflows/actors/get-last-run.workflow.json');

--- a/nodes/Apify/__tests__/workflows/actors/get-last-run.workflow.json
+++ b/nodes/Apify/__tests__/workflows/actors/get-last-run.workflow.json
@@ -10,7 +10,8 @@
 					"mode": "list",
 					"cachedResultName": "Google Search Results Scraper",
 					"cachedResultUrl": "https://console.com/actors/nFJndFXA5zjCTuudP/input"
-				}
+				},
+				"status": "ABORTED"
 			},
 			"id": "874a4468-0c56-4818-baa0-41967a17550a",
 			"name": "Get last run",

--- a/nodes/Apify/resources/actor-runs/get-user-runs-list/properties.ts
+++ b/nodes/Apify/resources/actor-runs/get-user-runs-list/properties.ts
@@ -48,8 +48,8 @@ descending order. By default, they are sorted in ascending order.`,
 	{
 		displayName: 'Status',
 		name: 'status',
-		description: `Return only runs with the provided terminal status ([available
-statuses](https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle))`,
+		description: `Return only runs with the provided terminal status, available
+statuses: https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle`,
 		default: 'SUCCEEDED',
 		type: 'options',
 		options: [

--- a/nodes/Apify/resources/actors/get-last-run/execute.ts
+++ b/nodes/Apify/resources/actors/get-last-run/execute.ts
@@ -8,6 +8,7 @@ import { apiRequest } from '../../../resources/genericFunctions';
 
 export async function getLastRun(this: IExecuteFunctions, i: number): Promise<INodeExecutionData> {
 	const actorId = this.getNodeParameter('actorId', i) as { value: string };
+	const status = this.getNodeParameter('status', i) as string;
 
 	if (!actorId) {
 		throw new NodeOperationError(this.getNode(), 'Actor ID is required');
@@ -17,6 +18,7 @@ export async function getLastRun(this: IExecuteFunctions, i: number): Promise<IN
 		const apiResult = await apiRequest.call(this, {
 			method: 'GET',
 			uri: `/v2/acts/${actorId.value}/runs/last`,
+			qs: { status },
 		});
 
 		return { json: { ...apiResult.data } };

--- a/nodes/Apify/resources/actors/get-last-run/properties.ts
+++ b/nodes/Apify/resources/actors/get-last-run/properties.ts
@@ -30,9 +30,20 @@ export const properties: INodeProperties[] = [
 	{
 		displayName: 'Status',
 		name: 'status',
-		description: 'Filter for the run status',
+		description:
+			'Return only runs with the provided status. See the dropdown options or the Apify documentation https://docs.apify.com/platform/actors/running/runs-and-builds#lifecycle.',
 		default: 'SUCCEEDED',
-		type: 'string',
+		type: 'options',
+		options: [
+			{ name: 'ABORTED', value: 'ABORTED' },
+			{ name: 'ABORTING', value: 'ABORTING' },
+			{ name: 'FAILED', value: 'FAILED' },
+			{ name: 'READY', value: 'READY' },
+			{ name: 'RUNNING', value: 'RUNNING' },
+			{ name: 'SUCCEEDED', value: 'SUCCEEDED' },
+			{ name: 'TIMED-OUT', value: 'TIMED-OUT' },
+			{ name: 'TIMING-OUT', value: 'TIMING-OUT' },
+		],
 		displayOptions: {
 			show: {
 				resource: ['Actors'],


### PR DESCRIPTION

![obrazek](https://github.com/user-attachments/assets/20bd1d2f-479a-46fe-b646-a99bfd6914e3)

@drobnikj Is it okay to also include the non-terminal run statuses? get-user-runs-list contains only terminal status