### PR TITLE
fix: edit regex for URL resource-locators

### DIFF
--- a/nodes/Apify/resources/actorResourceLocator.ts
+++ b/nodes/Apify/resources/actorResourceLocator.ts
@@ -29,7 +29,7 @@ const resourceLocatorProperty: INodeProperties = {
 					properties: {
 						// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input
 						// https://console.apify.com/actors/AtBpiepuIUNs2k2ku
-						regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+)(/input)?',
+						regex: 'https://console.apify.com/actors/([a-zA-Z0-9]+).*',
 						errorMessage: 'Not a valid Actor URL',
 					},
 				},
@@ -38,7 +38,7 @@ const resourceLocatorProperty: INodeProperties = {
 				type: 'regex',
 				// https://console.apify.com/actors/AtBpiepuIUNs2k2ku/input -> AtBpiepuIUNs2k2ku
 				// https://console.apify.com/actors/AtBpiepuIUNs2k2ku -> AtBpiepuIUNs2k2ku
-				regex: `https://console.apify.com/actors/([a-zA-Z0-9]+)`,
+				regex: `https://console.apify.com/actors/([a-zA-Z0-9]+).*`,
 			},
 		},
 		{

--- a/nodes/Apify/resources/actorTaskResourceLocator.ts
+++ b/nodes/Apify/resources/actorTaskResourceLocator.ts
@@ -29,7 +29,7 @@ const resourceLocatorProperty: INodeProperties = {
 					properties: {
 						// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input
 						// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY
-						regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+)(/input)?',
+						regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+).*',
 						errorMessage: 'Not a valid Apify Actor Task URL',
 					},
 				},
@@ -38,7 +38,7 @@ const resourceLocatorProperty: INodeProperties = {
 				type: 'regex',
 				// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY/input -> WAtmhr6rhfBnwqKDY
 				// https://console.apify.com/actors/tasks/WAtmhr6rhfBnwqKDY -> WAtmhr6rhfBnwqKDY
-				regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+)',
+				regex: 'https://console.apify.com/actors/tasks/([a-zA-Z0-9]+).*',
 			},
 		},
 		{

--- a/nodes/Apify/resources/runResourceLocator.ts
+++ b/nodes/Apify/resources/runResourceLocator.ts
@@ -28,8 +28,7 @@ const resourceLocatorProperty: INodeProperties = {
 					type: 'regex',
 					properties: {
 						// https://console.apify.com/actors/runs/RDfcScrqIYHW0jfNF#output
-						regex:
-							'https://console.apify.com/actors(/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+)(#(output|log))?',
+						regex: 'https://console.apify.com/actors(/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+).*',
 						errorMessage: 'Not a valid Apify Actor Run URL',
 					},
 				},
@@ -37,7 +36,7 @@ const resourceLocatorProperty: INodeProperties = {
 			extractValue: {
 				type: 'regex',
 				// https://console.apify.com/actors/runs/RDfcScrqIYHW0jfNF#output -> RDfcScrqIYHW0jfNF
-				regex: 'https://console.apify.com/actors(?:/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+)',
+				regex: 'https://console.apify.com/actors(?:/[a-zA-Z0-9]+)?/runs/([a-zA-Z0-9]+).*',
 			},
 		},
 		{


### PR DESCRIPTION
- a small change regarding the resource locators (actors, tasks and runs) which have "By URL" variant
- this regex now accepts the URL up until the resource ID is found (the first catch group) then the rest is ignored -> e.g. `https://console.apify.com/actors/nFJndFXA5zjCTuudP/the/rest/is-ignored`
