### PR TITLE
fix: pass correct build number for run-actor

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -155,14 +155,15 @@ describe('Apify Node', () => {
 		describe('run-actor', () => {
 			it('should run the run-actor workflow', async () => {
 				const mockRunActor = fixtures.runActorResult();
+				const mockBuild = fixtures.getBuildResult();
 
 				const scope = nock('https://api.apify.com')
 					.get('/v2/acts/nFJndFXA5zjCTuudP')
 					.reply(200, fixtures.getActorResult())
 					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
-					.reply(200, fixtures.getBuildResult())
+					.reply(200, mockBuild)
 					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
-					.query({ waitForFinish: 0 })
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber })
 					.reply(200, mockRunActor);
 
 				const runActorWorkflow = require('./workflows/actors/run-actor.workflow.json');
@@ -185,15 +186,16 @@ describe('Apify Node', () => {
 
 			it('should run the run-actor workflow and wait for finish', async () => {
 				const mockRunActor = fixtures.runActorResult();
+				const mockBuild = fixtures.getBuildResult();
 				const mockFinishedRun = fixtures.getRunResult();
 
 				const scope = nock('https://api.apify.com')
 					.get('/v2/acts/nFJndFXA5zjCTuudP')
 					.reply(200, fixtures.getActorResult())
 					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
-					.reply(200, fixtures.getBuildResult())
+					.reply(200, mockBuild)
 					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
-					.query({ waitForFinish: 0 })
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber })
 					.reply(200, mockRunActor)
 					.get('/v2/actor-runs/Icz6E0IHX0c40yEi7')
 					.reply(200, mockFinishedRun);

--- a/nodes/Apify/resources/actors/run-actor/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor/execute.ts
@@ -61,7 +61,7 @@ export async function runActor(this: IExecuteFunctions, i: number): Promise<INod
 	const qs: Record<string, any> = {};
 	if (timeout != null) qs.timeout = timeout;
 	if (memory != null) qs.memory = memory;
-	if (build?.buildTag) qs.build = build.buildTag;
+	if (build?.buildNumber) qs.build = build.buildNumber;
 	qs.waitForFinish = 0; // set initial run actor to not wait for finish
 
 	// 6. Run the actor


### PR DESCRIPTION
## After changes
### without build tag input
![Screenshot 2025-07-08 at 11 14 21](https://github.com/user-attachments/assets/7738625f-2e00-4654-a037-b5aa30d6d3f1)

### with passed build tag
![Screenshot 2025-07-08 at 11 15 03](https://github.com/user-attachments/assets/bfb2f766-879f-464b-807c-b4b69831b550)

## Actor's builds
![Screenshot 2025-07-08 at 11 12 21](https://github.com/user-attachments/assets/15b2dbcf-38f1-47bc-afd6-bbd0c4e6a791)
