### PR TITLE
feat: add dropdown for RAM memory select

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -163,7 +163,7 @@ describe('Apify Node', () => {
 					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
 					.reply(200, mockBuild)
 					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
-					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber })
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber, memory: 1024 })
 					.reply(200, mockRunActor);
 
 				const runActorWorkflow = require('./workflows/actors/run-actor.workflow.json');
@@ -195,7 +195,7 @@ describe('Apify Node', () => {
 					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
 					.reply(200, mockBuild)
 					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
-					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber })
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber, memory: 1024 })
 					.reply(200, mockRunActor)
 					.get('/v2/actor-runs/Icz6E0IHX0c40yEi7')
 					.reply(200, mockFinishedRun);

--- a/nodes/Apify/resources/actor-tasks/run-task/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/properties.ts
@@ -53,13 +53,6 @@ export const properties: INodeProperties[] = [
 		typeOptions: {
 			maxValue: 60,
 		},
-		routing: {
-			request: {
-				qs: {
-					waitForFinish: '={{ $value || $value === 0 ? $value : undefined }}',
-				},
-			},
-		},
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],
@@ -74,13 +67,6 @@ export const properties: INodeProperties[] = [
 timeout specified in the task settings.`,
 		default: null,
 		type: 'number',
-		routing: {
-			request: {
-				qs: {
-					timeout: '={{ $value || $value === 0 ? $value : undefined }}',
-				},
-			},
-		},
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],
@@ -91,18 +77,22 @@ timeout specified in the task settings.`,
 	{
 		displayName: 'Memory',
 		name: 'memory',
-		description: `Memory limit for the run, in megabytes. The amount of memory can be set
-to a power of 2 with a minimum of 128. By default, the run uses a memory
-limit specified in the task settings.`,
-		default: null,
-		type: 'number',
-		routing: {
-			request: {
-				qs: {
-					memory: '={{ $value }}',
-				},
-			},
-		},
+		description:
+			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the task settings.',
+		default: 1024,
+		type: 'options',
+		options: [
+			{ name: '128 MB', value: 128 },
+			{ name: '256 MB', value: 256 },
+			{ name: '512 MB', value: 512 },
+			{ name: '1024 MB (1 GB)', value: 1024 },
+			{ name: '2048 MB (2 GB)', value: 2048 },
+			{ name: '4096 MB (4 GB)', value: 4096 },
+			{ name: '8192 MB (8 GB)', value: 8192 },
+			{ name: '16384 MB (16 GB)', value: 16384 },
+			{ name: '32768 MB (32 GB)', value: 32768 },
+			{ name: '65536 MB (64 GB)', value: 65536 },
+		],
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],
@@ -118,13 +108,6 @@ number. By default, the run uses the build specified in the task
 settings (typically \`latest\`).`,
 		default: '',
 		type: 'string',
-		routing: {
-			request: {
-				qs: {
-					build: '={{ $value }}',
-				},
-			},
-		},
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],

--- a/nodes/Apify/resources/actor-tasks/run-task/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/properties.ts
@@ -91,7 +91,6 @@ timeout specified in the task settings.`,
 			{ name: '8192 MB (8 GB)', value: 8192 },
 			{ name: '16384 MB (16 GB)', value: 16384 },
 			{ name: '32768 MB (32 GB)', value: 32768 },
-			{ name: '65536 MB (64 GB)', value: 65536 },
 		],
 		displayOptions: {
 			show: {

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -58,11 +58,22 @@ timeout specified in the default run configuration for the Actor.`,
 	{
 		displayName: 'Memory',
 		name: 'memory',
-		description: `Memory limit for the run, in megabytes. The amount of memory can be set
-to a power of 2 with a minimum of 128. By default, the run uses a memory
-limit specified in the default run configuration for the Actor.`,
-		default: null,
-		type: 'number',
+		description:
+			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the default run configuration for the Actor.',
+		default: 1024,
+		type: 'options',
+		options: [
+			{ name: '128 MB', value: 128 },
+			{ name: '256 MB', value: 256 },
+			{ name: '512 MB', value: 512 },
+			{ name: '1024 MB (1 GB)', value: 1024 },
+			{ name: '2048 MB (2 GB)', value: 2048 },
+			{ name: '4096 MB (4 GB)', value: 4096 },
+			{ name: '8192 MB (8 GB)', value: 8192 },
+			{ name: '16384 MB (16 GB)', value: 16384 },
+			{ name: '32768 MB (32 GB)', value: 32768 },
+			{ name: '65536 MB (64 GB)', value: 65536 },
+		],
 		displayOptions: {
 			show: {
 				resource: ['Actors'],

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -72,7 +72,6 @@ timeout specified in the default run configuration for the Actor.`,
 			{ name: '8192 MB (8 GB)', value: 8192 },
 			{ name: '16384 MB (16 GB)', value: 16384 },
 			{ name: '32768 MB (32 GB)', value: 32768 },
-			{ name: '65536 MB (64 GB)', value: 65536 },
 		],
 		displayOptions: {
 			show: {


### PR DESCRIPTION
- replaced the number-input with a dropdown, same values as with IFTTT's "Run actor" and "Run task"
- 1GB is default (because default has to be set and is mandatory)

![Screenshot 2025-07-09 at 11 03 54](https://github.com/user-attachments/assets/a346f76f-248e-4470-8050-801660c37d02)
