### PR TITLE
chore: improve docs and add oauth2 self-hosted-notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is an n8n community node that integrates [Apify](https://apify.com) with yo
 
 ## Table of contents
 
-- [Installation](#installation)
+- [Installation on self hosted instance](#installation-self-hosted)
+- [Installation on n8n cloud](#installation-n8n-cloud)
+- [Installation for development and contributing](#installation-development-and-contributing)
 - [Operations](#operations)
 - [Credentials](#credentials)
 - [Compatibility](#compatibility)
@@ -16,7 +18,31 @@ This is an n8n community node that integrates [Apify](https://apify.com) with yo
 - [Version History](#version-history)
 - [Troubleshooting](#troubleshooting)
 
-## Installation
+## Installation (self-hosted)
+
+To install the Apify community node directly from the n8n Editor UI:
+
+1. Open your n8n instance.
+2. Go to **Settings > Community Nodes**
+3. Select **Install**.
+4. Enter the npm package name: `@apify/n8n-nodes-apify` to install the latest version. To install a specific version (e.g 0.4.4) enter `@apify/n8n-nodes-apify@0.4.4`. All versions are available [here](https://www.npmjs.com/package/@apify/n8n-nodes-apify?activeTab=versions)
+5. Agree to the [risks](https://docs.n8n.io/integrations/community-nodes/risks/) of using community nodes and select **Install**
+6. The node is now available to use in your workflows.
+
+## Installation (n8n Cloud)
+
+If you’re using n8n Cloud, installing community nodes is even simpler:
+
+1. Go to the **Canvas** and open the **nodes panel**.
+2. Search for **Apify** in the community node registry.
+3. Click **Install node** to add the Apify node to your instance.
+
+
+ > On n8n cloud users can choose not to show verified community nodes. Instance owners can toggle this in the Cloud Admin Panel. To install the Apify node, make sure the installation of verified community nodes is enabled. 
+
+
+## Installation (development and contributing) 
+To contribute to our Apify node, you can install the node and link it to your n8n instance. Follow the steps below:
 
 ### ⚙️ Prerequisites
 

--- a/credentials/ApifyOAuth2Api.credentials.ts
+++ b/credentials/ApifyOAuth2Api.credentials.ts
@@ -9,9 +9,6 @@ export class ApifyOAuth2Api implements ICredentialType {
 
 	displayName = 'Apify OAuth2 API';
 
-	// TODO: documentation URL for Apify OAuth2 API missing
-	documentationUrl = 'https://docs.apify.com/api/v2';
-
 	properties: INodeProperties[] = [
 		{
 			displayName: 'Grant Type',
@@ -32,10 +29,14 @@ export class ApifyOAuth2Api implements ICredentialType {
 			default: 'https://console-backend.apify.com/oauth/apps/token',
 		},
 		{
-			displayName: 'Scope',
+			displayName: 'Scope (do not change)',
 			name: 'scope',
-			type: 'hidden',
+			type: 'string',
 			default: `${scopes.join(' ')}`,
+			noDataExpression: true,
+			displayOptions: {
+				hideOnCloud: true,
+			},
 		},
 		{
 			displayName: 'Auth URI Query Parameters',
@@ -60,6 +61,16 @@ export class ApifyOAuth2Api implements ICredentialType {
 			name: 'clientSecret',
 			type: 'hidden',
 			default: '',
+		},
+		{
+			displayName:
+				'This credential type is not available on self hosted n8n instances, please use an API key instead.',
+			name: 'notice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				hideOnCloud: true,
+			},
 		},
 	];
 }


### PR DESCRIPTION
Added more info on cloud setup: https://github.com/orgs/apify/projects/18/views/3?pane=issue&itemId=3188741014&issue=apify%7Capify-ifttt-integration%7C235
Add notice for OAuth2 in self-hosted instances: https://github.com/apify/apify-ifttt-integration/issues/238