### PR TITLE
fix: remove set timeout function

### DIFF
--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -1,4 +1,5 @@
 import {
+	sleep,
 	NodeApiError,
 	NodeOperationError,
 	type IDataObject,
@@ -139,9 +140,7 @@ export async function pollRunStatus(
 				message: `Error polling run status: ${err}`,
 			});
 		}
-		await new Promise(
-			(resolve) => setTimeout(resolve, 1000), // 1 second polling interval
-		);
+		await sleep(1000); // 1 second polling interval
 	}
 	return lastRunData;
 }


### PR DESCRIPTION
n8n team requested that we do not use the `setTimeout` function. Instead they suggested to use the `sleep` function on the `n8n-workflow` package.

Slack: https://apify.slack.com/archives/C08S2N3NNJK/p1753370556168789

The modules effected by the change are following: **Run Actor**, **Run Task** and **Scrape Single URL** 

<img width="939" height="191" alt="Screenshot 2025-07-29 at 12 42 21" src="https://github.com/user-attachments/assets/979106a1-9ea9-4fe2-ba41-c18779a0800c" />
