### PR TITLE
feat: add run actor or task and get dataset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
 				'n8n-nodes-base/node-execute-block-missing-continue-on-fail': 'off',
 				'n8n-nodes-base/node-resource-description-filename-against-convention': 'off',
 				'n8n-nodes-base/node-param-fixed-collection-type-unsorted-items': 'off',
+				'n8n-nodes-base/node-param-default-wrong-for-options': 'off',
 			},
 		},
 	],

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -209,18 +209,14 @@ describe('Apify Node', () => {
 				const [nodeResult] = nodeResults;
 				expect(nodeResult.executionStatus).toBe('success');
 
-				const data = getTaskData(nodeResult);
-				expect(typeof data).toBe('object');
-				expect(data).toBeDefined();
-				expect(data).toHaveProperty('runResult');
-				expect(data).toHaveProperty('datasetItems');
-				expect(data!.runResult).toEqual(mockFinishedRun.data);
-				expect(data!.datasetItems).toEqual(mockItems);
+				const data = getTaskArrayData(nodeResult);
+				expect(Array.isArray(data)).toBe(true);
+				expect(data?.map((item) => item.json)).toEqual(mockItems);
 
 				expect(scope.isDone()).toBe(true);
 			});
 
-			it('should run the run-task-and-get-dataset workflow with ABORTED status', async () => {
+			it('should throw if the run-task-and-get-dataset workflow ends with ABORTED status', async () => {
 				const mockRunTask = fixtures.runActorResult();
 				const mockAbortedRun = fixtures.getLastRunResult({ status: 'ABORTED' });
 
@@ -239,14 +235,7 @@ describe('Apify Node', () => {
 				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run task and get dataset');
 				expect(nodeResults.length).toBe(1);
 				const [nodeResult] = nodeResults;
-				expect(nodeResult.executionStatus).toBe('success');
-
-				const data = getTaskData(nodeResult);
-				expect(typeof data).toBe('object');
-				expect(data).toBeDefined();
-				expect(data).toHaveProperty('runResult');
-				expect(data).not.toHaveProperty('datasetItems');
-				expect(data!.runResult).toEqual(mockAbortedRun.data);
+				expect(nodeResult.executionStatus).toBe('error');
 
 				expect(scope.isDone()).toBe(true);
 			});
@@ -379,18 +368,14 @@ describe('Apify Node', () => {
 				const [nodeResult] = nodeResults;
 				expect(nodeResult.executionStatus).toBe('success');
 
-				const data = getTaskData(nodeResult);
-				expect(typeof data).toBe('object');
-				expect(data).toBeDefined();
-				expect(data).toHaveProperty('runResult');
-				expect(data).toHaveProperty('datasetItems');
-				expect(data!.runResult).toEqual(mockFinishedRun.data);
-				expect(data!.datasetItems).toEqual(mockItems);
+				const data = getTaskArrayData(nodeResult);
+				expect(Array.isArray(data)).toBe(true);
+				expect(data?.map((item) => item.json)).toEqual(mockItems);
 
 				expect(scope.isDone()).toBe(true);
 			});
 
-			it('should run the run-actor-and-get-dataset workflow with ABORTED status', async () => {
+			it('should throw if the run-actor-and-get-dataset workflow ends with ABORTED status', async () => {
 				const mockRunActor = fixtures.runActorResult();
 				const mockBuild = fixtures.getBuildResult();
 				const mockAbortedRun = fixtures.getLastRunResult({ status: 'ABORTED' });
@@ -414,18 +399,12 @@ describe('Apify Node', () => {
 				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run actor and get dataset');
 				expect(nodeResults.length).toBe(1);
 				const [nodeResult] = nodeResults;
-				expect(nodeResult.executionStatus).toBe('success');
-
-				const data = getTaskData(nodeResult);
-				expect(typeof data).toBe('object');
-				expect(data).toBeDefined();
-				expect(data).toHaveProperty('runResult');
-				expect(data).not.toHaveProperty('datasetItems');
-				expect(data!.runResult).toEqual(mockAbortedRun.data);
+				expect(nodeResult.executionStatus).toBe('error');
 
 				expect(scope.isDone()).toBe(true);
 			});
 		});
+
 		describe('scrape-single-url', () => {
 			it('should run the scrape-single-url workflow', async () => {
 				const mockRunActor = fixtures.runActorResult();

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -1,3 +1,4 @@
+import nock from 'nock';
 import { Apify } from '../Apify.node';
 import { executeWorkflow } from './utils/executeWorkflow';
 import { CredentialsHelper } from './utils/credentialHelper';
@@ -5,7 +6,8 @@ import { getRunTaskDataByNodeName, getTaskData } from './utils/getNodeResultData
 import getRunWorkflow from './workflows/actor-runs/get-run.workflow.json';
 import getUserRunsListWorkflow from './workflows/actor-runs/get-user-runs-list.workflow.json';
 import getRunsWorkflow from './workflows/actor-runs/get-runs.workflow.json';
-import nock from 'nock';
+import runActorAndGetDatasetWorkflow from './workflows/actors/run-actor-and-get-dataset.workflow.json';
+import runTaskAndGetDatasetWorkflow from './workflows/actor-tasks/run-task-and-get-dataset.workflow.json';
 import * as fixtures from './utils/fixtures';
 import * as helpers from '../helpers';
 import { getTaskArrayData } from './utils/getNodeResultData';
@@ -178,6 +180,77 @@ describe('Apify Node', () => {
 				expect(scope.isDone()).toBe(true);
 			});
 		});
+
+		describe('run-task-and-get-dataset', () => {
+			it('should run the run-task-and-get-dataset workflow', async () => {
+				const mockRunTask = fixtures.runActorResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const mockItems = fixtures.getItemsResult();
+
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.post('/v2/actor-tasks/PwUDLcG3zMyT8E4vq/runs')
+					.query({ waitForFinish: 0, memory: 1024 })
+					.reply(200, mockRunTask)
+					.get(`/v2/actor-runs/${mockRunTask.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, mockItems);
+
+				const { executionData } = await executeWorkflow({
+					credentialsHelper,
+					workflow: runTaskAndGetDatasetWorkflow,
+				});
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run task and get dataset');
+				expect(nodeResults.length).toBe(1);
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				expect(typeof data).toBe('object');
+				expect(data).toBeDefined();
+				expect(data).toHaveProperty('runResult');
+				expect(data).toHaveProperty('datasetItems');
+				expect(data!.runResult).toEqual(mockFinishedRun.data);
+				expect(data!.datasetItems).toEqual(mockItems);
+
+				expect(scope.isDone()).toBe(true);
+			});
+
+			it('should run the run-task-and-get-dataset workflow with ABORTED status', async () => {
+				const mockRunTask = fixtures.runActorResult();
+				const mockAbortedRun = fixtures.getLastRunResult({ status: 'ABORTED' });
+
+				const scope = nock('https://api.apify.com')
+					.post('/v2/actor-tasks/PwUDLcG3zMyT8E4vq/runs')
+					.query({ waitForFinish: 0, memory: 1024 })
+					.reply(200, mockRunTask)
+					.get(`/v2/actor-runs/${mockRunTask.data.id}`)
+					.reply(200, mockAbortedRun);
+
+				const { executionData } = await executeWorkflow({
+					credentialsHelper,
+					workflow: runTaskAndGetDatasetWorkflow,
+				});
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run task and get dataset');
+				expect(nodeResults.length).toBe(1);
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				expect(typeof data).toBe('object');
+				expect(data).toBeDefined();
+				expect(data).toHaveProperty('runResult');
+				expect(data).not.toHaveProperty('datasetItems');
+				expect(data!.runResult).toEqual(mockAbortedRun.data);
+
+				expect(scope.isDone()).toBe(true);
+			});
+		});
 	});
 
 	describe('actors', () => {
@@ -269,6 +342,86 @@ describe('Apify Node', () => {
 				// exptect polled terminal run as result
 				expect(data).not.toEqual(mockRunActor.data);
 				expect(data).toEqual(mockFinishedRun.data);
+
+				expect(scope.isDone()).toBe(true);
+			});
+		});
+		describe('run-actor-and-get-dataset', () => {
+			it('should run the run-actor-and-get-dataset workflow', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockBuild = fixtures.getBuildResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const mockItems = fixtures.getItemsResult();
+
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.get('/v2/acts/nFJndFXA5zjCTuudP')
+					.reply(200, fixtures.getActorResult())
+					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
+					.reply(200, mockBuild)
+					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber, memory: 1024 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, mockItems);
+
+				const { executionData } = await executeWorkflow({
+					credentialsHelper,
+					workflow: runActorAndGetDatasetWorkflow,
+				});
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run actor and get dataset');
+				expect(nodeResults.length).toBe(1);
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				expect(typeof data).toBe('object');
+				expect(data).toBeDefined();
+				expect(data).toHaveProperty('runResult');
+				expect(data).toHaveProperty('datasetItems');
+				expect(data!.runResult).toEqual(mockFinishedRun.data);
+				expect(data!.datasetItems).toEqual(mockItems);
+
+				expect(scope.isDone()).toBe(true);
+			});
+
+			it('should run the run-actor-and-get-dataset workflow with ABORTED status', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockBuild = fixtures.getBuildResult();
+				const mockAbortedRun = fixtures.getLastRunResult({ status: 'ABORTED' });
+
+				const scope = nock('https://api.apify.com')
+					.get('/v2/acts/nFJndFXA5zjCTuudP')
+					.reply(200, fixtures.getActorResult())
+					.get('/v2/acts/nFJndFXA5zjCTuudP/builds/default')
+					.reply(200, mockBuild)
+					.post('/v2/acts/nFJndFXA5zjCTuudP/runs')
+					.query({ waitForFinish: 0, build: mockBuild.data.buildNumber, memory: 1024 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockAbortedRun);
+
+				const { executionData } = await executeWorkflow({
+					credentialsHelper,
+					workflow: runActorAndGetDatasetWorkflow,
+				});
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Run actor and get dataset');
+				expect(nodeResults.length).toBe(1);
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				expect(typeof data).toBe('object');
+				expect(data).toBeDefined();
+				expect(data).toHaveProperty('runResult');
+				expect(data).not.toHaveProperty('datasetItems');
+				expect(data!.runResult).toEqual(mockAbortedRun.data);
 
 				expect(scope.isDone()).toBe(true);
 			});

--- a/nodes/Apify/__tests__/utils/fixtures.ts
+++ b/nodes/Apify/__tests__/utils/fixtures.ts
@@ -193,7 +193,11 @@ export const getRunTaskResult = () => {
 	};
 };
 
-export const getLastRunResult = () => {
+type GetLastRunOverrides = {
+	status?: 'SUCCEEDED' | 'FAILED' | 'ABORTED' | 'TIMED-OUT';
+};
+
+export const getLastRunResult = (overrides: GetLastRunOverrides = {}) => {
 	return {
 		data: {
 			id: '8Ai57jgykDRefjXZ2',
@@ -202,7 +206,7 @@ export const getLastRunResult = () => {
 			actorTaskId: 'PwUDLcG3zMyT8E4vq',
 			startedAt: '2025-06-16T15:25:16.265Z',
 			finishedAt: '2025-06-16T15:25:27.109Z',
-			status: 'SUCCEEDED',
+			status: overrides.status || 'SUCCEEDED',
 			statusMessage: 'Finished! Total 3 requests: 3 succeeded, 0 failed.',
 			isStatusMessageTerminal: true,
 			meta: {

--- a/nodes/Apify/__tests__/workflows/actor-tasks/run-task-and-get-dataset.workflow.json
+++ b/nodes/Apify/__tests__/workflows/actor-tasks/run-task-and-get-dataset.workflow.json
@@ -1,0 +1,45 @@
+{
+	"name": "Run task and get dataset workflow",
+	"nodes": [
+		{
+			"parameters": {
+				"resource": "Actor tasks",
+				"operation": "Run task and get dataset",
+				"actorTaskId": {
+					"__rl": true,
+					"value": "PwUDLcG3zMyT8E4vq",
+					"mode": "list",
+					"cachedResultName": "Google Search Results Scraper Task",
+					"cachedResultUrl": "https://console.com/actor-tasks/PwUDLcG3zMyT8E4vq/input"
+				},
+				"useCustomBody": true,
+				"customBody": "{\n    \"maxPagesPerQuery\": 1,\n    \"resultsPerPage\": 2,\n    \"queries\": \"javascript\\ntypescript\"\n}",
+				"memory": 1024
+			},
+			"id": "8b21ab5d-baff-48f1-9512-831704fd2df4",
+			"name": "Run task and get dataset",
+			"type": "n8n-nodes-apify.apify",
+			"typeVersion": 1,
+			"position": [1460, 520],
+			"credentials": {
+				"apifyApi": {
+					"id": "dJAynKkN2pRqy3Ko",
+					"name": "Apify account"
+				}
+			}
+		}
+	],
+	"pinData": {},
+	"connections": {},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "3407ee9f-0aac-4990-804f-702d06bbc85b",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "3f65ba173ae28613be507e94c0a98de4375527c55e31b7fc173a4edee4e2ded3"
+	},
+	"id": "OFLCq8UoIVInQv2Y",
+	"tags": []
+}

--- a/nodes/Apify/__tests__/workflows/actors/run-actor-and-get-dataset.workflow.json
+++ b/nodes/Apify/__tests__/workflows/actors/run-actor-and-get-dataset.workflow.json
@@ -1,0 +1,43 @@
+{
+	"name": "Run actor and get dataset workflow",
+	"nodes": [
+		{
+			"parameters": {
+				"operation": "Run actor and get dataset",
+				"actorId": {
+					"__rl": true,
+					"value": "nFJndFXA5zjCTuudP",
+					"mode": "list",
+					"cachedResultName": "Google Search Results Scraper",
+					"cachedResultUrl": "https://console.com/actors/nFJndFXA5zjCTuudP/input"
+				},
+				"customBody": "{\n    \"maxPagesPerQuery\": 1,\n    \"resultsPerPage\": 2,\n    \"queries\": \"javascript\\ntypescript\"\n}",
+				"memory": 1024
+			},
+			"id": "8b21ab5d-baff-48f1-9512-831704fd2df4",
+			"name": "Run actor and get dataset",
+			"type": "n8n-nodes-apify.apify",
+			"typeVersion": 1,
+			"position": [1460, 520],
+			"credentials": {
+				"apifyApi": {
+					"id": "dJAynKkN2pRqy3Ko",
+					"name": "Apify account"
+				}
+			}
+		}
+	],
+	"pinData": {},
+	"connections": {},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "3407ee9f-0aac-4990-804f-702d06bbc85b",
+	"meta": {
+		"templateCredsSetupCompleted": true,
+		"instanceId": "3f65ba173ae28613be507e94c0a98de4375527c55e31b7fc173a4edee4e2ded3"
+	},
+	"id": "OFLCq8UoIVInQv2Y",
+	"tags": []
+}

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -1,4 +1,16 @@
 export const WEB_CONTENT_SCRAPER_ACTOR_ID = 'aYG0l9s7dbB7j3gbS';
 export const APIFY_API_URL = 'https://api.apify.com';
 export const TERMINAL_RUN_STATUSES = ['SUCCEEDED', 'FAILED', 'TIMED-OUT', 'ABORTED'];
-export const WAIT_FOR_FINISH_POLL_INTERVAL = 1000; //
+export const WAIT_FOR_FINISH_POLL_INTERVAL = 1000;
+
+export const memoryOptions = [
+	{ name: '128 MB', value: 128 },
+	{ name: '256 MB', value: 256 },
+	{ name: '512 MB', value: 512 },
+	{ name: '1024 MB (1 GB)', value: 1024 },
+	{ name: '2048 MB (2 GB)', value: 2048 },
+	{ name: '4096 MB (4 GB)', value: 4096 },
+	{ name: '8192 MB (8 GB)', value: 8192 },
+	{ name: '16384 MB (16 GB)', value: 16384 },
+	{ name: '32768 MB (32 GB)', value: 32768 },
+];

--- a/nodes/Apify/resources/actor-tasks/index.ts
+++ b/nodes/Apify/resources/actor-tasks/index.ts
@@ -2,8 +2,9 @@ import { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
 import { runHooks } from './hooks';
 
 import * as runTask from './run-task';
+import * as runTaskAndGetDataset from './run-task-and-get-dataset';
 
-const operations: INodePropertyOptions[] = [runTask.option];
+const operations: INodePropertyOptions[] = [runTask.option, runTaskAndGetDataset.option];
 
 export const name = 'Actor tasks';
 
@@ -26,7 +27,11 @@ operationSelect.options = operations;
 // set the default operation
 operationSelect.default = operations.length > 0 ? operations[0].value : '';
 
-export const rawProperties: INodeProperties[] = [operationSelect, ...runTask.properties];
+export const rawProperties: INodeProperties[] = [
+	operationSelect,
+	...runTask.properties,
+	...runTaskAndGetDataset.properties,
+];
 
 const { properties, methods } = runHooks(rawProperties);
 

--- a/nodes/Apify/resources/actor-tasks/router.ts
+++ b/nodes/Apify/resources/actor-tasks/router.ts
@@ -2,7 +2,9 @@ import { IExecuteFunctions, INodeExecutionData, NodeOperationError } from 'n8n-w
 
 import { name as actorTaskResourceName } from './index';
 import { name as runTaskOperationName } from './run-task';
+import { name as runTaskAndGetDatasetOperationName } from './run-task-and-get-dataset';
 import { runTask } from './run-task/execute';
+import { runTaskAndGetDataset } from './run-task-and-get-dataset/execute';
 
 export async function actorTasksRouter(
 	this: IExecuteFunctions,
@@ -21,6 +23,9 @@ export async function actorTasksRouter(
 	switch (operation) {
 		case runTaskOperationName:
 			return await runTask.call(this, i);
+
+		case runTaskAndGetDatasetOperationName:
+			return await runTaskAndGetDataset.call(this, i);
 
 		default:
 			throw new NodeOperationError(

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
@@ -61,11 +61,9 @@ export async function runTaskAndGetDataset(
 	}
 
 	if (lastRunData?.status !== 'SUCCEEDED') {
-		return {
-			json: {
-				runResult: lastRunData,
-			},
-		};
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ${runId} did not finish with status SUCCEEDED. Run status: ${lastRunData?.status}`,
+		});
 	}
 
 	const datasetItems = await apiRequest.call(this, {

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
@@ -4,7 +4,7 @@ import {
 	NodeApiError,
 	NodeOperationError,
 } from 'n8n-workflow';
-import { apiRequest, isUsedAsAiTool, pollRunStatus } from '../../genericFunctions';
+import { apiRequest, pollRunStatus } from '../../genericFunctions';
 
 export async function runTaskAndGetDataset(
 	this: IExecuteFunctions,
@@ -63,14 +63,6 @@ export async function runTaskAndGetDataset(
 		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
 		qs: { format: 'json' },
 	});
-
-	if (isUsedAsAiTool(this.getNode().type)) {
-		return {
-			json: {
-				...datasetItems,
-			},
-		};
-	}
 
 	return {
 		json: {

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
@@ -1,0 +1,81 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	NodeApiError,
+	NodeOperationError,
+} from 'n8n-workflow';
+import { apiRequest, isUsedAsAiTool, pollRunStatus } from '../../genericFunctions';
+
+export async function runTaskAndGetDataset(
+	this: IExecuteFunctions,
+	i: number,
+): Promise<INodeExecutionData> {
+	const actorTaskId = this.getNodeParameter('actorTaskId', i, undefined, {
+		extractValue: true,
+	}) as string;
+	const input = this.getNodeParameter('customBody', i, {}) as object;
+	const timeout = this.getNodeParameter('timeout', i, null) as number | null;
+	const memory = this.getNodeParameter('memory', i, null) as number | null;
+	const build = this.getNodeParameter('build', i, '') as string;
+
+	if (!actorTaskId) {
+		throw new NodeOperationError(this.getNode(), 'Task ID is required');
+	}
+
+	const qs: Record<string, any> = {};
+	if (timeout != null) qs.timeout = timeout;
+	if (memory != null) qs.memory = memory;
+	if (build) qs.build = build;
+	qs.waitForFinish = 0; // always start run without waiting
+
+	const apiResult = await apiRequest.call(this, {
+		method: 'POST',
+		uri: `/v2/actor-tasks/${actorTaskId}/runs`,
+		body: input,
+		qs,
+	});
+
+	if (!apiResult?.data?.id) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ID not found after running the task`,
+		});
+	}
+
+	const runId = apiResult.data.id;
+	const lastRunData = await pollRunStatus.call(this, runId);
+
+	if (!lastRunData?.defaultDatasetId) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ${runId} did not create a dataset`,
+		});
+	}
+
+	if (lastRunData?.status !== 'SUCCEEDED') {
+		return {
+			json: {
+				runResult: lastRunData,
+			},
+		};
+	}
+
+	const datasetItems = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
+		qs: { format: 'json' },
+	});
+
+	if (isUsedAsAiTool(this.getNode().type)) {
+		return {
+			json: {
+				...datasetItems,
+			},
+		};
+	}
+
+	return {
+		json: {
+			runResult: lastRunData,
+			datasetItems: datasetItems,
+		},
+	};
+}

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
@@ -9,7 +9,7 @@ import { apiRequest, customBodyParser, pollRunStatus } from '../../genericFuncti
 export async function runTaskAndGetDataset(
 	this: IExecuteFunctions,
 	i: number,
-): Promise<INodeExecutionData> {
+): Promise<INodeExecutionData[]> {
 	const actorTaskId = this.getNodeParameter('actorTaskId', i, undefined, {
 		extractValue: true,
 	}) as string;
@@ -72,10 +72,5 @@ export async function runTaskAndGetDataset(
 		qs: { format: 'json' },
 	});
 
-	return {
-		json: {
-			runResult: lastRunData,
-			datasetItems: datasetItems,
-		},
-	};
+	return this.helpers.returnJsonArray(datasetItems);
 }

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/hooks.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/hooks.ts
@@ -1,0 +1,14 @@
+import { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+
+export function runHooks(
+	option: INodePropertyOptions,
+	properties: INodeProperties[],
+): {
+	option: INodePropertyOptions;
+	properties: INodeProperties[];
+} {
+	return {
+		option,
+		properties,
+	};
+}

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/index.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/index.ts
@@ -1,0 +1,18 @@
+import { INodePropertyOptions } from 'n8n-workflow';
+
+import { properties as rawProperties } from './properties';
+import { runHooks } from './hooks';
+
+export const name = 'Run task and get dataset';
+
+const rawOption: INodePropertyOptions = {
+	name: 'Run Task and Get Dataset',
+	value: 'Run task and get dataset',
+	action: 'Run task and get dataset',
+	description:
+		'Runs an Actor task, waits for it to finish, and finally returns the dataset items. You can optionally override the Actor’s input configuration by providing a custom body.',
+};
+
+const { properties, option } = runHooks(rawOption, rawProperties);
+
+export { option, properties };

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
@@ -1,5 +1,7 @@
 import { INodeProperties } from 'n8n-workflow';
 
+import * as helpers from '../../../helpers';
+
 export const properties: INodeProperties[] = [
 	{
 		displayName: 'Actor Task',
@@ -64,17 +66,7 @@ timeout specified in the task settings.`,
 			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the task settings.',
 		default: 1024,
 		type: 'options',
-		options: [
-			{ name: '128 MB', value: 128 },
-			{ name: '256 MB', value: 256 },
-			{ name: '512 MB', value: 512 },
-			{ name: '1024 MB (1 GB)', value: 1024 },
-			{ name: '2048 MB (2 GB)', value: 2048 },
-			{ name: '4096 MB (4 GB)', value: 4096 },
-			{ name: '8192 MB (8 GB)', value: 8192 },
-			{ name: '16384 MB (16 GB)', value: 16384 },
-			{ name: '32768 MB (32 GB)', value: 32768 },
-		],
+		options: helpers.consts.memoryOptions,
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
@@ -1,0 +1,100 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const properties: INodeProperties[] = [
+	{
+		displayName: 'Actor Task',
+		name: 'actorTaskId',
+		required: true,
+		description: 'Task ID or a tilde-separated username and task name',
+		default: 'janedoe~my-task',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Use Custom Body',
+		name: 'useCustomBody',
+		type: 'boolean',
+		description: 'Whether to use a custom body',
+		// default to false since Task should use task-defined input for its Actor
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Input (JSON)',
+		name: 'customBody',
+		type: 'json',
+		default: '{}',
+		description: 'Custom body to send',
+		displayOptions: {
+			show: {
+				useCustomBody: [true],
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Timeout',
+		name: 'timeout',
+		description: `Optional timeout for the run, in seconds. By default, the run uses a
+timeout specified in the task settings.`,
+		default: null,
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Memory',
+		name: 'memory',
+		description:
+			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the task settings.',
+		default: 1024,
+		type: 'options',
+		options: [
+			{ name: '128 MB', value: 128 },
+			{ name: '256 MB', value: 256 },
+			{ name: '512 MB', value: 512 },
+			{ name: '1024 MB (1 GB)', value: 1024 },
+			{ name: '2048 MB (2 GB)', value: 2048 },
+			{ name: '4096 MB (4 GB)', value: 4096 },
+			{ name: '8192 MB (8 GB)', value: 8192 },
+			{ name: '16384 MB (16 GB)', value: 16384 },
+			{ name: '32768 MB (32 GB)', value: 32768 },
+		],
+		displayOptions: {
+			show: {
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Build',
+		name: 'build',
+		description: `Specifies the Actor build to run. It can be either a build tag or build
+number. By default, the run uses the build specified in the task
+settings (typically \`latest\`).`,
+		default: '',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['Actor tasks'],
+				operation: ['Run task and get dataset'],
+			},
+		},
+	},
+];

--- a/nodes/Apify/resources/actor-tasks/run-task/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/execute.ts
@@ -4,17 +4,27 @@ import {
 	NodeApiError,
 	NodeOperationError,
 } from 'n8n-workflow';
-import { apiRequest, pollRunStatus } from '../../../resources/genericFunctions';
+import { apiRequest, customBodyParser, pollRunStatus } from '../../../resources/genericFunctions';
 
 export async function runTask(this: IExecuteFunctions, i: number): Promise<INodeExecutionData> {
 	const actorTaskId = this.getNodeParameter('actorTaskId', i, undefined, {
 		extractValue: true,
 	}) as string;
-	const input = this.getNodeParameter('customBody', i, {}) as object;
+	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string | object;
 	const waitForFinish = this.getNodeParameter('waitForFinish', i) as boolean;
 	const timeout = this.getNodeParameter('timeout', i, null) as number | null;
 	const memory = this.getNodeParameter('memory', i, null) as number | null;
 	const build = this.getNodeParameter('build', i, '') as string;
+
+	let input: any;
+	try {
+		input = customBodyParser(rawStringifiedInput);
+	} catch (err) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Could not parse custom body: ${rawStringifiedInput}`,
+		);
+	}
 
 	if (!actorTaskId) {
 		throw new NodeOperationError(this.getNode(), 'Task ID is required');

--- a/nodes/Apify/resources/actor-tasks/run-task/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/properties.ts
@@ -1,5 +1,7 @@
 import { INodeProperties } from 'n8n-workflow';
 
+import * as helpers from '../../../helpers';
+
 export const properties: INodeProperties[] = [
 	{
 		displayName: 'Actor Task',
@@ -78,17 +80,7 @@ timeout specified in the task settings.`,
 			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the task settings.',
 		default: 1024,
 		type: 'options',
-		options: [
-			{ name: '128 MB', value: 128 },
-			{ name: '256 MB', value: 256 },
-			{ name: '512 MB', value: 512 },
-			{ name: '1024 MB (1 GB)', value: 1024 },
-			{ name: '2048 MB (2 GB)', value: 2048 },
-			{ name: '4096 MB (4 GB)', value: 4096 },
-			{ name: '8192 MB (8 GB)', value: 8192 },
-			{ name: '16384 MB (16 GB)', value: 16384 },
-			{ name: '32768 MB (32 GB)', value: 32768 },
-		],
+		options: helpers.consts.memoryOptions,
 		displayOptions: {
 			show: {
 				resource: ['Actor tasks'],

--- a/nodes/Apify/resources/actors/index.ts
+++ b/nodes/Apify/resources/actors/index.ts
@@ -4,9 +4,11 @@ import { runHooks } from './hooks';
 import * as runActor from './run-actor';
 import * as scrapeSingleUrl from './scrape-single-url';
 import * as getLastRun from './get-last-run';
+import * as runActorAndGetDataset from './run-actor-and-get-dataset';
 
 const operations: INodePropertyOptions[] = [
 	runActor.option,
+	runActorAndGetDataset.option,
 	scrapeSingleUrl.option,
 	getLastRun.option,
 ];
@@ -35,6 +37,7 @@ operationSelect.default = operations.length > 0 ? operations[0].value : '';
 export const rawProperties: INodeProperties[] = [
 	operationSelect,
 	...runActor.properties,
+	...runActorAndGetDataset.properties,
 	...scrapeSingleUrl.properties,
 	...getLastRun.properties,
 ];

--- a/nodes/Apify/resources/actors/router.ts
+++ b/nodes/Apify/resources/actors/router.ts
@@ -2,11 +2,13 @@ import { IExecuteFunctions, INodeExecutionData, NodeOperationError } from 'n8n-w
 
 import { name as actorResourceName } from './index';
 import { name as runActorOperationName } from './run-actor';
+import { name as runActorAndGetDatasetOperationName } from './run-actor-and-get-dataset';
 import { scrapeSingleUrlName as scrapeSingleUrlOperationName } from './scrape-single-url';
 import { name as getLastRunOperationName } from './get-last-run';
 import { runActor } from './run-actor/execute';
 import { scrapeSingleUrl } from './scrape-single-url/execute';
 import { getLastRun } from './get-last-run/execute';
+import { runActorAndGetDataset } from './run-actor-and-get-dataset/execute';
 
 export async function actorsRouter(
 	this: IExecuteFunctions,
@@ -25,6 +27,8 @@ export async function actorsRouter(
 	switch (operation) {
 		case runActorOperationName:
 			return await runActor.call(this, i);
+		case runActorAndGetDatasetOperationName:
+			return await runActorAndGetDataset.call(this, i);
 		case scrapeSingleUrlOperationName:
 			return await scrapeSingleUrl.call(this, i);
 		case getLastRunOperationName:

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -86,11 +86,9 @@ export async function runActorAndGetDataset(
 	}
 
 	if (lastRunData?.status !== 'SUCCEEDED') {
-		return {
-			json: {
-				runResult: lastRunData,
-			},
-		};
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ${runId} did not finish with status SUCCEEDED. Run status: ${lastRunData?.status}`,
+		});
 	}
 
 	const datasetItems = await apiRequest.call(this, {

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -1,0 +1,181 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	NodeApiError,
+	NodeOperationError,
+} from 'n8n-workflow';
+import { apiRequest, isUsedAsAiTool, pollRunStatus } from '../../genericFunctions';
+
+export async function runActorAndGetDataset(
+	this: IExecuteFunctions,
+	i: number,
+): Promise<INodeExecutionData> {
+	const actorId = this.getNodeParameter('actorId', i, undefined, {
+		extractValue: true,
+	}) as string;
+	const timeout = this.getNodeParameter('timeout', i) as number | null;
+	const memory = this.getNodeParameter('memory', i) as number | null;
+	const buildParam = this.getNodeParameter('build', i) as string | null;
+	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string;
+
+	let userInput: any;
+	try {
+		userInput = rawStringifiedInput ? JSON.parse(rawStringifiedInput) : {};
+	} catch (err) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Could not parse custom body: ${rawStringifiedInput}`,
+		);
+	}
+
+	if (!actorId) {
+		throw new NodeOperationError(this.getNode(), 'Actor ID is required');
+	}
+
+	// 1. Get the actor details
+	const actor = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/acts/${actorId}`,
+	});
+	if (!actor || !actor.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Actor ${actorId} not found`,
+		});
+	}
+	const actorData = actor.data;
+
+	// 2. Build selection logic
+	let build: any;
+	if (buildParam) {
+		build = await getBuildByTag.call(this, actorId, buildParam, actorData);
+	} else {
+		build = await getDefaultBuild.call(this, actorId);
+	}
+
+	// 3. Get default input for this build
+	const defaultInput = getDefaultInputsFromBuild(build);
+
+	// 4. Merge default input and user's input (user's input overrides)
+	const mergedInput = { ...defaultInput, ...userInput };
+
+	// 5. Prepare query string
+	const qs: Record<string, any> = {};
+	if (timeout != null) qs.timeout = timeout;
+	if (memory != null) qs.memory = memory;
+	if (build?.buildNumber) qs.build = build.buildNumber;
+	qs.waitForFinish = 0; // set initial run actor to not wait for finish
+
+	// 6. Run the actor
+	const run = await runActorApi.call(this, actorId, mergedInput, qs);
+	if (!run?.data?.id) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ID not found after running the actor`,
+		});
+	}
+
+	// 7. Start polling for run status until it reaches a terminal state
+	// This loop is infinite and will only stop when a terminal status is reached,
+	// or when the workflow maximum timeout is hit, as set in your n8n configuration.
+	const runId = run.data.id;
+	const lastRunData = await pollRunStatus.call(this, runId);
+
+	if (!lastRunData?.defaultDatasetId) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ${runId} did not create a dataset`,
+		});
+	}
+
+	if (lastRunData?.status !== 'SUCCEEDED') {
+		return {
+			json: {
+				runResult: lastRunData,
+			},
+		};
+	}
+
+	const datasetItems = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
+		qs: { format: 'json' },
+	});
+
+	if (isUsedAsAiTool(this.getNode().type)) {
+		return {
+			json: {
+				...datasetItems,
+			},
+		};
+	}
+
+	return {
+		json: {
+			runResult: lastRunData,
+			datasetItems: datasetItems,
+		},
+	};
+}
+
+async function getBuildByTag(
+	this: IExecuteFunctions,
+	actorId: string,
+	buildTag: string,
+	actorData: any,
+) {
+	const buildByTag = actorData.taggedBuilds && actorData.taggedBuilds[buildTag];
+	if (!buildByTag?.buildId) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Build tag '${buildTag}' does not exist for actor ${actorData.title ?? actorData.name ?? actorId}`,
+		});
+	}
+	const buildResp = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/actor-builds/${buildByTag.buildId}`,
+	});
+	if (!buildResp || !buildResp.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Build with ID '${buildByTag.buildId}' not found for actor ${actorId}`,
+		});
+	}
+	return buildResp.data;
+}
+
+async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
+	const defaultBuildResp = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/acts/${actorId}/builds/default`,
+	});
+	if (!defaultBuildResp || !defaultBuildResp.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Could not fetch default build for actor ${actorId}`,
+		});
+	}
+	return defaultBuildResp.data;
+}
+
+function getDefaultInputsFromBuild(build: any) {
+	const buildInputProperties = build?.actorDefinition?.input?.properties;
+	const defaultInput: Record<string, any> = {};
+	if (buildInputProperties && typeof buildInputProperties === 'object') {
+		for (const [key, property] of Object.entries(buildInputProperties)) {
+			if (
+				property &&
+				typeof property === 'object' &&
+				'prefill' in property &&
+				(property as any).prefill !== undefined &&
+				(property as any).prefill !== null
+			) {
+				defaultInput[key] = (property as any).prefill;
+			}
+		}
+	}
+	return defaultInput;
+}
+
+async function runActorApi(this: IExecuteFunctions, actorId: string, mergedInput: any, qs: any) {
+	return await apiRequest.call(this, {
+		method: 'POST',
+		uri: `/v2/acts/${actorId}/runs`,
+		body: mergedInput,
+		qs,
+	});
+}

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -4,7 +4,7 @@ import {
 	NodeApiError,
 	NodeOperationError,
 } from 'n8n-workflow';
-import { apiRequest, pollRunStatus } from '../../genericFunctions';
+import { apiRequest, customBodyParser, pollRunStatus } from '../../genericFunctions';
 
 export async function runActorAndGetDataset(
 	this: IExecuteFunctions,
@@ -16,11 +16,11 @@ export async function runActorAndGetDataset(
 	const timeout = this.getNodeParameter('timeout', i) as number | null;
 	const memory = this.getNodeParameter('memory', i) as number | null;
 	const buildParam = this.getNodeParameter('build', i) as string | null;
-	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string;
+	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string | object;
 
 	let userInput: any;
 	try {
-		userInput = rawStringifiedInput ? JSON.parse(rawStringifiedInput) : {};
+		userInput = customBodyParser(rawStringifiedInput);
 	} catch (err) {
 		throw new NodeOperationError(
 			this.getNode(),

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -1,15 +1,11 @@
-import {
-	IExecuteFunctions,
-	INodeExecutionData,
-	NodeApiError,
-	NodeOperationError,
-} from 'n8n-workflow';
-import { apiRequest, customBodyParser, pollRunStatus } from '../../genericFunctions';
+import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
+import { apiRequest } from '../../genericFunctions';
+import { executeActor } from '../../executeActor';
 
 export async function runActorAndGetDataset(
 	this: IExecuteFunctions,
 	i: number,
-): Promise<INodeExecutionData> {
+): Promise<INodeExecutionData[]> {
 	const actorId = this.getNodeParameter('actorId', i, undefined, {
 		extractValue: true,
 	}) as string;
@@ -18,66 +14,14 @@ export async function runActorAndGetDataset(
 	const buildParam = this.getNodeParameter('build', i) as string | null;
 	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string | object;
 
-	let userInput: any;
-	try {
-		userInput = customBodyParser(rawStringifiedInput);
-	} catch (err) {
-		throw new NodeOperationError(
-			this.getNode(),
-			`Could not parse custom body: ${rawStringifiedInput}`,
-		);
-	}
-
-	if (!actorId) {
-		throw new NodeOperationError(this.getNode(), 'Actor ID is required');
-	}
-
-	// 1. Get the actor details
-	const actor = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/acts/${actorId}`,
+	const { runId, lastRunData } = await executeActor.call(this, {
+		actorId,
+		timeout,
+		memory,
+		buildParam,
+		rawStringifiedInput,
+		waitForFinish: true,
 	});
-	if (!actor || !actor.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Actor ${actorId} not found`,
-		});
-	}
-	const actorData = actor.data;
-
-	// 2. Build selection logic
-	let build: any;
-	if (buildParam) {
-		build = await getBuildByTag.call(this, actorId, buildParam, actorData);
-	} else {
-		build = await getDefaultBuild.call(this, actorId);
-	}
-
-	// 3. Get default input for this build
-	const defaultInput = getDefaultInputsFromBuild(build);
-
-	// 4. Merge default input and user's input (user's input overrides)
-	const mergedInput = { ...defaultInput, ...userInput };
-
-	// 5. Prepare query string
-	const qs: Record<string, any> = {};
-	if (timeout != null) qs.timeout = timeout;
-	if (memory != null) qs.memory = memory;
-	if (build?.buildNumber) qs.build = build.buildNumber;
-	qs.waitForFinish = 0; // set initial run actor to not wait for finish
-
-	// 6. Run the actor
-	const run = await runActorApi.call(this, actorId, mergedInput, qs);
-	if (!run?.data?.id) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Run ID not found after running the actor`,
-		});
-	}
-
-	// 7. Start polling for run status until it reaches a terminal state
-	// This loop is infinite and will only stop when a terminal status is reached,
-	// or when the workflow maximum timeout is hit, as set in your n8n configuration.
-	const runId = run.data.id;
-	const lastRunData = await pollRunStatus.call(this, runId);
 
 	if (!lastRunData?.defaultDatasetId) {
 		throw new NodeApiError(this.getNode(), {
@@ -97,75 +41,5 @@ export async function runActorAndGetDataset(
 		qs: { format: 'json' },
 	});
 
-	return {
-		json: {
-			runResult: lastRunData,
-			datasetItems: datasetItems,
-		},
-	};
-}
-
-async function getBuildByTag(
-	this: IExecuteFunctions,
-	actorId: string,
-	buildTag: string,
-	actorData: any,
-) {
-	const buildByTag = actorData.taggedBuilds && actorData.taggedBuilds[buildTag];
-	if (!buildByTag?.buildId) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Build tag '${buildTag}' does not exist for actor ${actorData.title ?? actorData.name ?? actorId}`,
-		});
-	}
-	const buildResp = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/actor-builds/${buildByTag.buildId}`,
-	});
-	if (!buildResp || !buildResp.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Build with ID '${buildByTag.buildId}' not found for actor ${actorId}`,
-		});
-	}
-	return buildResp.data;
-}
-
-async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
-	const defaultBuildResp = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/acts/${actorId}/builds/default`,
-	});
-	if (!defaultBuildResp || !defaultBuildResp.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Could not fetch default build for actor ${actorId}`,
-		});
-	}
-	return defaultBuildResp.data;
-}
-
-function getDefaultInputsFromBuild(build: any) {
-	const buildInputProperties = build?.actorDefinition?.input?.properties;
-	const defaultInput: Record<string, any> = {};
-	if (buildInputProperties && typeof buildInputProperties === 'object') {
-		for (const [key, property] of Object.entries(buildInputProperties)) {
-			if (
-				property &&
-				typeof property === 'object' &&
-				'prefill' in property &&
-				(property as any).prefill !== undefined &&
-				(property as any).prefill !== null
-			) {
-				defaultInput[key] = (property as any).prefill;
-			}
-		}
-	}
-	return defaultInput;
-}
-
-async function runActorApi(this: IExecuteFunctions, actorId: string, mergedInput: any, qs: any) {
-	return await apiRequest.call(this, {
-		method: 'POST',
-		uri: `/v2/acts/${actorId}/runs`,
-		body: mergedInput,
-		qs,
-	});
+	return this.helpers.returnJsonArray(datasetItems);
 }

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -4,7 +4,7 @@ import {
 	NodeApiError,
 	NodeOperationError,
 } from 'n8n-workflow';
-import { apiRequest, isUsedAsAiTool, pollRunStatus } from '../../genericFunctions';
+import { apiRequest, pollRunStatus } from '../../genericFunctions';
 
 export async function runActorAndGetDataset(
 	this: IExecuteFunctions,
@@ -98,14 +98,6 @@ export async function runActorAndGetDataset(
 		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
 		qs: { format: 'json' },
 	});
-
-	if (isUsedAsAiTool(this.getNode().type)) {
-		return {
-			json: {
-				...datasetItems,
-			},
-		};
-	}
 
 	return {
 		json: {

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/hooks.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/hooks.ts
@@ -1,0 +1,14 @@
+import { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+
+export function runHooks(
+	option: INodePropertyOptions,
+	properties: INodeProperties[],
+): {
+	option: INodePropertyOptions;
+	properties: INodeProperties[];
+} {
+	return {
+		option,
+		properties,
+	};
+}

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/index.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/index.ts
@@ -1,0 +1,17 @@
+import { INodePropertyOptions } from 'n8n-workflow';
+
+import { properties as rawProperties } from './properties';
+import { runHooks } from './hooks';
+
+export const name = 'Run actor and get dataset';
+
+const rawOption: INodePropertyOptions = {
+	name: 'Run an Actor and Get Dataset',
+	value: 'Run actor and get dataset',
+	action: 'Run an Actor and get dataset',
+	description: 'Runs an Actor, waits for it to finish, and finally returns the dataset items',
+};
+
+const { properties, option } = runHooks(rawOption, rawProperties);
+
+export { option, properties };

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
@@ -1,0 +1,97 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const properties: INodeProperties[] = [
+	{
+		displayName: 'Actor Source',
+		name: 'actorSource',
+		type: 'hidden',
+		default: 'recentlyUsed',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Actor',
+		name: 'actorId',
+		required: true,
+		description: 'Actor ID or a tilde-separated username and Actor name',
+		default: 'janedoe~my-actor',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Input JSON',
+		name: 'customBody',
+		type: 'json',
+		default: '{}',
+		description:
+			'JSON input for the Actor run, which you can find on the Actor input page in Apify Console. If empty, the run uses the input specified in the default run configuration.',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Timeout',
+		name: 'timeout',
+		description: `Optional timeout for the run, in seconds. By default, the run uses a
+timeout specified in the default run configuration for the Actor.`,
+		default: null,
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Memory',
+		name: 'memory',
+		description:
+			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the default run configuration for the Actor.',
+		default: 1024,
+		type: 'options',
+		options: [
+			{ name: '128 MB', value: 128 },
+			{ name: '256 MB', value: 256 },
+			{ name: '512 MB', value: 512 },
+			{ name: '1024 MB (1 GB)', value: 1024 },
+			{ name: '2048 MB (2 GB)', value: 2048 },
+			{ name: '4096 MB (4 GB)', value: 4096 },
+			{ name: '8192 MB (8 GB)', value: 8192 },
+			{ name: '16384 MB (16 GB)', value: 16384 },
+			{ name: '32768 MB (32 GB)', value: 32768 },
+		],
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+	{
+		displayName: 'Build Tag',
+		name: 'build',
+		description: `Specifies the Actor build tag to run. By default, the run uses the build specified in the default run
+configuration for the Actor (typically \`latest\`).`,
+		default: '',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Run actor and get dataset'],
+			},
+		},
+	},
+];

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
@@ -1,5 +1,7 @@
 import { INodeProperties } from 'n8n-workflow';
 
+import * as helpers from '../../../helpers';
+
 export const properties: INodeProperties[] = [
 	{
 		displayName: 'Actor Source',
@@ -62,17 +64,7 @@ timeout specified in the default run configuration for the Actor.`,
 			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the default run configuration for the Actor.',
 		default: 1024,
 		type: 'options',
-		options: [
-			{ name: '128 MB', value: 128 },
-			{ name: '256 MB', value: 256 },
-			{ name: '512 MB', value: 512 },
-			{ name: '1024 MB (1 GB)', value: 1024 },
-			{ name: '2048 MB (2 GB)', value: 2048 },
-			{ name: '4096 MB (4 GB)', value: 4096 },
-			{ name: '8192 MB (8 GB)', value: 8192 },
-			{ name: '16384 MB (16 GB)', value: 16384 },
-			{ name: '32768 MB (32 GB)', value: 32768 },
-		],
+		options: helpers.consts.memoryOptions,
 		displayOptions: {
 			show: {
 				resource: ['Actors'],

--- a/nodes/Apify/resources/actors/run-actor/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor/execute.ts
@@ -1,10 +1,5 @@
-import {
-	IExecuteFunctions,
-	INodeExecutionData,
-	NodeApiError,
-	NodeOperationError,
-} from 'n8n-workflow';
-import { apiRequest, customBodyParser, pollRunStatus } from '../../genericFunctions';
+import { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { executeActor } from '../../executeActor';
 
 export async function runActor(this: IExecuteFunctions, i: number): Promise<INodeExecutionData> {
 	const actorId = this.getNodeParameter('actorId', i, undefined, {
@@ -16,139 +11,16 @@ export async function runActor(this: IExecuteFunctions, i: number): Promise<INod
 	const waitForFinish = this.getNodeParameter('waitForFinish', i) as boolean;
 	const rawStringifiedInput = this.getNodeParameter('customBody', i, '{}') as string | object;
 
-	let userInput: any;
-	try {
-		userInput = customBodyParser(rawStringifiedInput);
-	} catch (err) {
-		throw new NodeOperationError(
-			this.getNode(),
-			`Could not parse custom body: ${rawStringifiedInput}`,
-		);
-	}
-
-	if (!actorId) {
-		throw new NodeOperationError(this.getNode(), 'Actor ID is required');
-	}
-
-	// 1. Get the actor details
-	const actor = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/acts/${actorId}`,
+	const { lastRunData } = await executeActor.call(this, {
+		actorId,
+		timeout,
+		memory,
+		buildParam,
+		rawStringifiedInput,
+		waitForFinish,
 	});
-	if (!actor || !actor.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Actor ${actorId} not found`,
-		});
-	}
-	const actorData = actor.data;
 
-	// 2. Build selection logic
-	let build: any;
-	if (buildParam) {
-		build = await getBuildByTag.call(this, actorId, buildParam, actorData);
-	} else {
-		build = await getDefaultBuild.call(this, actorId);
-	}
-
-	// 3. Get default input for this build
-	const defaultInput = getDefaultInputsFromBuild(build);
-
-	// 4. Merge default input and user's input (user's input overrides)
-	const mergedInput = { ...defaultInput, ...userInput };
-
-	// 5. Prepare query string
-	const qs: Record<string, any> = {};
-	if (timeout != null) qs.timeout = timeout;
-	if (memory != null) qs.memory = memory;
-	if (build?.buildNumber) qs.build = build.buildNumber;
-	qs.waitForFinish = 0; // set initial run actor to not wait for finish
-
-	// 6. Run the actor
-	const run = await runActorApi.call(this, actorId, mergedInput, qs);
-	if (!run?.data?.id) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Run ID not found after running the actor`,
-		});
-	}
-
-	// 7a. If waitForFinish is false, return the run data immediately
-	if (!waitForFinish) {
-		return {
-			json: { ...run.data },
-		};
-	}
-
-	// 7b. Start polling for run status until it reaches a terminal state
-	// This loop is infinite and will only stop when a terminal status is reached,
-	// or when the workflow maximum timeout is hit, as set in your n8n configuration.
-	const runId = run.data.id;
-	const lastRunData = await pollRunStatus.call(this, runId);
 	return {
 		json: { ...lastRunData },
 	};
-}
-
-async function getBuildByTag(
-	this: IExecuteFunctions,
-	actorId: string,
-	buildTag: string,
-	actorData: any,
-) {
-	const buildByTag = actorData.taggedBuilds && actorData.taggedBuilds[buildTag];
-	if (!buildByTag?.buildId) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Build tag '${buildTag}' does not exist for actor ${actorData.title ?? actorData.name ?? actorId}`,
-		});
-	}
-	const buildResp = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/actor-builds/${buildByTag.buildId}`,
-	});
-	if (!buildResp || !buildResp.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Build with ID '${buildByTag.buildId}' not found for actor ${actorId}`,
-		});
-	}
-	return buildResp.data;
-}
-
-async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
-	const defaultBuildResp = await apiRequest.call(this, {
-		method: 'GET',
-		uri: `/v2/acts/${actorId}/builds/default`,
-	});
-	if (!defaultBuildResp || !defaultBuildResp.data) {
-		throw new NodeApiError(this.getNode(), {
-			message: `Could not fetch default build for actor ${actorId}`,
-		});
-	}
-	return defaultBuildResp.data;
-}
-
-function getDefaultInputsFromBuild(build: any) {
-	const buildInputProperties = build?.actorDefinition?.input?.properties;
-	const defaultInput: Record<string, any> = {};
-	if (buildInputProperties && typeof buildInputProperties === 'object') {
-		for (const [key, property] of Object.entries(buildInputProperties)) {
-			if (
-				property &&
-				typeof property === 'object' &&
-				'prefill' in property &&
-				(property as any).prefill !== undefined &&
-				(property as any).prefill !== null
-			) {
-				defaultInput[key] = (property as any).prefill;
-			}
-		}
-	}
-	return defaultInput;
-}
-
-async function runActorApi(this: IExecuteFunctions, actorId: string, mergedInput: any, qs: any) {
-	return await apiRequest.call(this, {
-		method: 'POST',
-		uri: `/v2/acts/${actorId}/runs`,
-		body: mergedInput,
-		qs,
-	});
 }

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -1,5 +1,7 @@
 import { INodeProperties } from 'n8n-workflow';
 
+import * as helpers from '../../../helpers';
+
 export const properties: INodeProperties[] = [
 	{
 		displayName: 'Actor Source',
@@ -76,17 +78,7 @@ timeout specified in the default run configuration for the Actor.`,
 			'Memory limit for the run, in megabytes. The amount of memory can be set to one of the available options. By default, the run uses a memory limit specified in the default run configuration for the Actor.',
 		default: 1024,
 		type: 'options',
-		options: [
-			{ name: '128 MB', value: 128 },
-			{ name: '256 MB', value: 256 },
-			{ name: '512 MB', value: 512 },
-			{ name: '1024 MB (1 GB)', value: 1024 },
-			{ name: '2048 MB (2 GB)', value: 2048 },
-			{ name: '4096 MB (4 GB)', value: 4096 },
-			{ name: '8192 MB (8 GB)', value: 8192 },
-			{ name: '16384 MB (16 GB)', value: 16384 },
-			{ name: '32768 MB (32 GB)', value: 32768 },
-		],
+		options: helpers.consts.memoryOptions,
 		displayOptions: {
 			show: {
 				resource: ['Actors'],

--- a/nodes/Apify/resources/executeActor.ts
+++ b/nodes/Apify/resources/executeActor.ts
@@ -1,0 +1,168 @@
+import { IExecuteFunctions, NodeApiError, NodeOperationError } from 'n8n-workflow';
+import { apiRequest, customBodyParser, pollRunStatus } from './genericFunctions';
+
+export interface ActorExecutionParams {
+	actorId: string;
+	timeout: number | null;
+	memory: number | null;
+	buildParam: string | null;
+	rawStringifiedInput: string | object;
+	waitForFinish?: boolean;
+}
+
+export interface ActorExecutionResult {
+	runId: string;
+	lastRunData: any;
+}
+
+export async function executeActor(
+	this: IExecuteFunctions,
+	params: ActorExecutionParams,
+): Promise<ActorExecutionResult> {
+	const {
+		actorId,
+		timeout,
+		memory,
+		buildParam,
+		rawStringifiedInput,
+		waitForFinish = false,
+	} = params;
+
+	let userInput: any;
+	try {
+		userInput = customBodyParser(rawStringifiedInput);
+	} catch (err) {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Could not parse custom body: ${rawStringifiedInput}`,
+		);
+	}
+
+	if (!actorId) {
+		throw new NodeOperationError(this.getNode(), 'Actor ID is required');
+	}
+
+	// 1. Get the actor details
+	const actor = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/acts/${actorId}`,
+	});
+	if (!actor || !actor.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Actor ${actorId} not found`,
+		});
+	}
+	const actorData = actor.data;
+
+	// 2. Build selection logic
+	let build: any;
+	if (buildParam) {
+		build = await getBuildByTag.call(this, actorId, buildParam, actorData);
+	} else {
+		build = await getDefaultBuild.call(this, actorId);
+	}
+
+	// 3. Get default input for this build
+	const defaultInput = getDefaultInputsFromBuild(build);
+
+	// 4. Merge default input and user's input (user's input overrides)
+	const mergedInput = { ...defaultInput, ...userInput };
+
+	// 5. Prepare query string
+	const qs: Record<string, any> = {};
+	if (timeout != null) qs.timeout = timeout;
+	if (memory != null) qs.memory = memory;
+	if (build?.buildNumber) qs.build = build.buildNumber;
+	qs.waitForFinish = 0; // set initial run actor to not wait for finish
+
+	// 6. Run the actor
+	const run = await runActorApi.call(this, actorId, mergedInput, qs);
+	if (!run?.data?.id) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Run ID not found after running the actor`,
+		});
+	}
+
+	const runId = run.data.id;
+	let lastRunData = run.data;
+
+	// 7. If waitForFinish is true, poll for run status until it reaches a terminal state
+	if (waitForFinish) {
+		lastRunData = await pollRunStatus.call(this, runId);
+	}
+
+	return {
+		runId,
+		lastRunData,
+	};
+}
+
+export async function getBuildByTag(
+	this: IExecuteFunctions,
+	actorId: string,
+	buildTag: string,
+	actorData: any,
+) {
+	const buildByTag = actorData.taggedBuilds && actorData.taggedBuilds[buildTag];
+	if (!buildByTag?.buildId) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Build tag '${buildTag}' does not exist for actor ${actorData.title ?? actorData.name ?? actorId}`,
+		});
+	}
+	const buildResp = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/actor-builds/${buildByTag.buildId}`,
+	});
+	if (!buildResp || !buildResp.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Build with ID '${buildByTag.buildId}' not found for actor ${actorId}`,
+		});
+	}
+	return buildResp.data;
+}
+
+export async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
+	const defaultBuildResp = await apiRequest.call(this, {
+		method: 'GET',
+		uri: `/v2/acts/${actorId}/builds/default`,
+	});
+	if (!defaultBuildResp || !defaultBuildResp.data) {
+		throw new NodeApiError(this.getNode(), {
+			message: `Could not fetch default build for actor ${actorId}`,
+		});
+	}
+	return defaultBuildResp.data;
+}
+
+export function getDefaultInputsFromBuild(build: any) {
+	const buildInputProperties = build?.actorDefinition?.input?.properties;
+	const defaultInput: Record<string, any> = {};
+	if (buildInputProperties && typeof buildInputProperties === 'object') {
+		for (const [key, property] of Object.entries(buildInputProperties)) {
+			if (
+				property &&
+				typeof property === 'object' &&
+				'prefill' in property &&
+				(property as any).prefill !== undefined &&
+				(property as any).prefill !== null
+			) {
+				defaultInput[key] = (property as any).prefill;
+			}
+		}
+	}
+	return defaultInput;
+}
+
+export async function runActorApi(
+	this: IExecuteFunctions,
+	actorId: string,
+	mergedInput: any,
+	qs: any,
+) {
+	return await apiRequest.call(this, {
+		method: 'POST',
+		uri: `/v2/acts/${actorId}/runs`,
+		body: mergedInput,
+		qs,
+	});
+}

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -195,8 +195,3 @@ export function customBodyParser(input: string | object) {
 		return input;
 	}
 }
-
-export function isUsedAsAiTool(nodeType: string): boolean {
-	const parts = nodeType.split('.');
-	return parts[parts.length - 1] === 'apifyTool';
-}

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -195,3 +195,8 @@ export function customBodyParser(input: string | object) {
 		return input;
 	}
 }
+
+export function isUsedAsAiTool(nodeType: string): boolean {
+	const parts = nodeType.split('.');
+	return parts[parts.length - 1] === 'apifyTool';
+}


### PR DESCRIPTION
Added "sibling" operations to "Run Actor" and "Run Task" which in comparison returns the dataset:
- dataset is along-side run-results if it's run in normal workflow
- dataset only (no run-result) if it's run in AI Tool

## Testing
_Run actor and get dataset_
| | screenshot |
|--------|--------|
| Normal workflow (returns with run-result) | <img width="1334" height="928" alt="Screenshot 2025-08-08 at 17 36 55" src="https://github.com/user-attachments/assets/121674c9-0428-4756-9bf8-1f7b3a72c8fd" /> |
| as AI tool | <img width="1706" height="970" alt="Screenshot 2025-08-08 at 18 41 01" src="https://github.com/user-attachments/assets/5436e108-754f-4417-9842-f89e636291b0" /> |

Same testing result for Run Task.

TODO:
- [x] test usage in AI Tool
- [x] add tests for these 2 operations 