### PR TITLE
fix: rewrite false descriptions

### DIFF
--- a/nodes/Apify/resources/actor-tasks/run-task/index.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/index.ts
@@ -10,7 +10,7 @@ const rawOption: INodePropertyOptions = {
 	value: 'Run task',
 	action: 'Run task',
 	description:
-		'Runs an Actor task and immediately returns its details without waiting for the run to complete. You can optionally override the Actor’s input configuration by providing a custom body.',
+		'Runs an Actor Task and return all associated details. You can optionally override the Actor’s input configuration by providing a custom body.',
 };
 
 const { properties, option } = runHooks(rawOption, rawProperties);

--- a/nodes/Apify/resources/actor-tasks/run-task/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/properties.ts
@@ -49,7 +49,7 @@ export const properties: INodeProperties[] = [
 		displayName: 'Wait for Finish',
 		name: 'waitForFinish',
 		description:
-			'Whether to wait for the run to finish. If true, the node will poll the run status until it reaches a terminal state (SUCCEEDED, FAILED, TIMED-OUT, ABORTED) or 5 minutes have passed. If false, the node will return immediately after starting the run.',
+			'Whether or not to wait for the run to finish before continuing. If true, the node will wait for the run to complete (successfully or not) before moving to the next node. Note: The maximum time the workflow will wait is limited by the workflow timeout setting in your n8n configuration.',
 		default: true,
 		type: 'boolean',
 		displayOptions: {

--- a/nodes/Apify/resources/actors/run-actor/index.ts
+++ b/nodes/Apify/resources/actors/run-actor/index.ts
@@ -9,7 +9,8 @@ const rawOption: INodePropertyOptions = {
 	name: 'Run an Actor',
 	value: 'Run actor',
 	action: 'Run an Actor',
-	description: 'Runs an Actor and immediately returns without waiting for the run to finish',
+	description:
+		'Runs an Actor. You can override the Actor’s input configuration by providing a custom body, which will override the prefilled input values.',
 };
 
 const { properties, option } = runHooks(rawOption, rawProperties);

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -47,7 +47,7 @@ export const properties: INodeProperties[] = [
 		displayName: 'Wait for Finish',
 		name: 'waitForFinish',
 		description:
-			'Whether to wait for the run to finish before continuing. If true, the node will wait for the run to complete (successfully or not) before moving to the next node. Note: The maximum time the workflow will wait is limited by the workflow timeout setting in your n8n configuration.',
+			'Whether or not to wait for the run to finish before continuing. If true, the node will wait for the run to complete (successfully or not) before moving to the next node. Note: The maximum time the workflow will wait is limited by the workflow timeout setting in your n8n configuration.',
 		default: true,
 		type: 'boolean',
 		displayOptions: {


### PR DESCRIPTION
There are some descriptions that do not match the correct behavior of the operation node / input.