### PR TITLE
feat: Add exponential backoff to requests

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -512,24 +512,25 @@ describe('Apify Node', () => {
 
 	describe('api calls', () => {
 		it('should retry the specified number of times with exponential delays', async () => {
+			const retryAbleCodes = [429, 500];
 			const storeId = 'yTfMu13hDFe9bRjx6';
 			const recordKey = 'INPUT';
 
-			let called = 0;
-			let apiCalls = nock('https://api.apify.com')
-				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-				.reply(500, () => called++)
-				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-				.reply(200, () => called++);
+			for (const code of retryAbleCodes) {
+				const scope = nock('https://api.apify.com')
+					.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
+					.reply(code)
+					.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
+					.reply(200);
 
-			const getKeyValueStoreRecordWorkflow = require('./workflows/key-value-stores/get-key-value-store-record.workflow.json');
-			await executeWorkflow({
-				credentialsHelper,
-				workflow: getKeyValueStoreRecordWorkflow,
-			});
+				const getKeyValueStoreRecordWorkflow = require('./workflows/key-value-stores/get-key-value-store-record.workflow.json');
+				await executeWorkflow({
+					credentialsHelper,
+					workflow: getKeyValueStoreRecordWorkflow,
+				});
 
-			expect(called).toBe(2);
-			expect(apiCalls.isDone()).toBe(true);
+				expect(scope.isDone()).toBe(true);
+			}
 		});
 	});
 });

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -512,25 +512,24 @@ describe('Apify Node', () => {
 
 	describe('api calls', () => {
 		it('should retry the specified number of times with exponential delays', async () => {
-			const retryAbleCodes = [429, 500];
 			const storeId = 'yTfMu13hDFe9bRjx6';
 			const recordKey = 'INPUT';
 
-			for (const code of retryAbleCodes) {
-				const scope = nock('https://api.apify.com')
-					.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-					.reply(code)
-					.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-					.reply(200);
+			const scope = nock('https://api.apify.com')
+				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
+				.reply(500)
+				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
+				.reply(429)
+				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
+				.reply(200);
 
-				const getKeyValueStoreRecordWorkflow = require('./workflows/key-value-stores/get-key-value-store-record.workflow.json');
-				await executeWorkflow({
-					credentialsHelper,
-					workflow: getKeyValueStoreRecordWorkflow,
-				});
+			const getKeyValueStoreRecordWorkflow = require('./workflows/key-value-stores/get-key-value-store-record.workflow.json');
+			await executeWorkflow({
+				credentialsHelper,
+				workflow: getKeyValueStoreRecordWorkflow,
+			});
 
-				expect(scope.isDone()).toBe(true);
-			}
+			expect(scope.isDone()).toBe(true);
 		});
 	});
 });

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -518,9 +518,9 @@ describe('Apify Node', () => {
 			let called = 0;
 			let apiCalls = nock('https://api.apify.com')
 				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-				.reply(500,() => (called++))
+				.reply(500, () => called++)
 				.get(`/v2/key-value-stores/${storeId}/records/${recordKey}`)
-				.reply(200,() => (called++));
+				.reply(200, () => called++);
 
 			const getKeyValueStoreRecordWorkflow = require('./workflows/key-value-stores/get-key-value-store-record.workflow.json');
 			await executeWorkflow({

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -17,4 +17,4 @@ export const memoryOptions = [
 
 export const DEFAULT_EXP_BACKOFF_INTERVAL = 1;
 export const DEFAULT_EXP_BACKOFF_EXPONENTIAL = 2;
-export const MAX_EXP_BAKCOFF_RETRIES = 5;
+export const DEFAULT_EXP_BACKOFF_RETRIES = 5;

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -14,3 +14,5 @@ export const memoryOptions = [
 	{ name: '16384 MB (16 GB)', value: 16384 },
 	{ name: '32768 MB (32 GB)', value: 32768 },
 ];
+
+export const MAX_API_CALL_RETRIES = 5;

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -15,4 +15,6 @@ export const memoryOptions = [
 	{ name: '32768 MB (32 GB)', value: 32768 },
 ];
 
-export const MAX_API_CALL_RETRIES = 5;
+export const DEFAULT_EXP_BACKOFF_INTERVAL = 1;
+export const DEFAULT_EXP_BACKOFF_EXPONENTIAL = 2;
+export const MAX_EXP_BAKCOFF_RETRIES = 5;

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -100,7 +100,7 @@ export async function retryWithExponentialBackoff(
 	logger: Logger,
 	fn: () => Promise<any>,
  	maxRetries: number = MAX_API_CALL_RETRIES,
-) {
+): Promise<any> {
 	let lastError;
 	for (let i = 0; i < maxRetries; i++) {
 		try {

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -7,6 +7,7 @@ import {
 	type IHookFunctions,
 	type ILoadOptionsFunctions,
 	type IRequestOptions,
+	type Logger,
 } from 'n8n-workflow';
 
 type IApiRequestOptions = IRequestOptions & { uri?: string };
@@ -93,15 +94,15 @@ function isStatusCodeRetryable(statusCode: number) {
  * @param maxRetries
  * @returns
  */
-async function retryWithExponentialBackoff(
-	logger: any,
+export async function retryWithExponentialBackoff(
+	logger: Logger,
 	fn: () => Promise<any>,
  	maxRetries: number = 5,
 ) {
 	let lastError;
 	for (let i = 0; i < maxRetries; i++) {
 		try {
-			logger?.debug(`Trying to call fn ${i}/${maxRetries}`);
+			logger.debug(`Trying to call fn ${i}/${maxRetries}`);
 			return await fn();
 		} catch (error) {
 			lastError = error;

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -9,7 +9,11 @@ import {
 	type IRequestOptions,
 	type Logger,
 } from 'n8n-workflow';
-import { DEFAULT_EXP_BACKOFF_EXPONENTIAL, DEFAULT_EXP_BACKOFF_INTERVAL, MAX_EXP_BAKCOFF_RETRIES } from '../helpers/consts';
+import {
+	DEFAULT_EXP_BACKOFF_EXPONENTIAL,
+	DEFAULT_EXP_BACKOFF_INTERVAL,
+	DEFAULT_EXP_BACKOFF_RETRIES,
+} from '../helpers/consts';
 
 type IApiRequestOptions = IRequestOptions & { uri?: string };
 
@@ -94,6 +98,8 @@ function isStatusCodeRetryable(statusCode: number) {
  * a code at all it is retried in 1s,2s,4s,.. up to maxRetries
  * @param logger
  * @param fn
+ * @param interval
+ * @param exponential
  * @param maxRetries
  * @returns
  */
@@ -102,7 +108,7 @@ export async function retryWithExponentialBackoff(
 	fn: () => Promise<any>,
 	interval: number = DEFAULT_EXP_BACKOFF_INTERVAL,
 	exponential: number = DEFAULT_EXP_BACKOFF_EXPONENTIAL,
-	maxRetries: number = MAX_EXP_BAKCOFF_RETRIES,
+	maxRetries: number = DEFAULT_EXP_BACKOFF_RETRIES,
 ): Promise<any> {
 	let lastError;
 	for (let i = 0; i < maxRetries; i++) {

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -85,8 +85,7 @@ export async function apiRequest(
  * because the error is probably caused by invalid URL (redirect 3xx) or invalid user input (4xx).
  */
 function isStatusCodeRetryable(statusCode: number) {
-	if (Number.isNaN(statusCode))
-		return false;
+	if (Number.isNaN(statusCode)) return false;
 
 	const RATE_LIMIT_EXCEEDED_STATUS_CODE = 429;
 	const isRateLimitError = statusCode === RATE_LIMIT_EXCEEDED_STATUS_CODE;

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -52,7 +52,9 @@ export async function apiRequest(
 			);
 		}
 
-		return await retryWithExponentialBackoff(this.logger,() => this.helpers.requestWithAuthentication.call(this, authenticationMethod, options));
+		return await retryWithExponentialBackoff(this.logger, () =>
+			this.helpers.requestWithAuthentication.call(this, authenticationMethod, options),
+		);
 	} catch (error) {
 		/**
 		 * using `error instanceof NodeApiError` results in `false`
@@ -86,7 +88,6 @@ function isStatusCodeRetryable(statusCode: number) {
 	return isRateLimitError || isInternalError;
 }
 
-
 /**
  * Wraps a function with exponential backoff.
  * If request fails with http code 500+ or doesn't return
@@ -99,7 +100,7 @@ function isStatusCodeRetryable(statusCode: number) {
 export async function retryWithExponentialBackoff(
 	logger: Logger,
 	fn: () => Promise<any>,
- 	maxRetries: number = MAX_API_CALL_RETRIES,
+	maxRetries: number = MAX_API_CALL_RETRIES,
 ): Promise<any> {
 	let lastError;
 	for (let i = 0; i < maxRetries; i++) {

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -85,6 +85,9 @@ export async function apiRequest(
  * because the error is probably caused by invalid URL (redirect 3xx) or invalid user input (4xx).
  */
 function isStatusCodeRetryable(statusCode: number) {
+	if (Number.isNaN(statusCode))
+		return false;
+
 	const RATE_LIMIT_EXCEEDED_STATUS_CODE = 429;
 	const isRateLimitError = statusCode === RATE_LIMIT_EXCEEDED_STATUS_CODE;
 	const isInternalError = statusCode >= 500;

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -112,7 +112,7 @@ export async function retryWithExponentialBackoff(
 				const sleepTimeSecs = Math.pow(2, i); //generate a new sleep time based from 2^i function
 				const sleepTimeMs = sleepTimeSecs * 1000;
 
-				logger?.debug(`sleepTimeMs ${sleepTimeMs}`);
+				logger.debug(`sleepTimeMs ${sleepTimeMs}`);
 				await sleep(sleepTimeMs);
 
 				continue;
@@ -120,7 +120,8 @@ export async function retryWithExponentialBackoff(
 			throw error;
 		}
 	}
-	throw lastError; //in case all of the maxRetries calls failed with no status or isStatusCodeRetryable throw the last error
+	//In case all of the calls failed with no status or isStatusCodeRetryable, throw the last error
+	throw lastError;
 }
 
 export async function apiRequestAllItems(

--- a/nodes/Apify/resources/key-value-stores/get-key-value-store-record/execute.ts
+++ b/nodes/Apify/resources/key-value-stores/get-key-value-store-record/execute.ts
@@ -20,16 +20,17 @@ export async function getKeyValueStoreRecord(
 	}
 
 	try {
-		const apiCallFn = () => this.helpers.httpRequestWithAuthentication.call(this, 'apifyApi', {
-			method: 'GET' as IHttpRequestMethods,
-			url: `${consts.APIFY_API_URL}/v2/key-value-stores/${storeId.value}/records/${recordKey.value}`,
-			headers: {
-				'x-apify-integration-platform': 'n8n',
-			},
-			returnFullResponse: true,
-			encoding: 'arraybuffer',
-		});
-		const apiResult = await retryWithExponentialBackoff(this.logger,apiCallFn);
+		const apiCallFn = () =>
+			this.helpers.httpRequestWithAuthentication.call(this, 'apifyApi', {
+				method: 'GET' as IHttpRequestMethods,
+				url: `${consts.APIFY_API_URL}/v2/key-value-stores/${storeId.value}/records/${recordKey.value}`,
+				headers: {
+					'x-apify-integration-platform': 'n8n',
+				},
+				returnFullResponse: true,
+				encoding: 'arraybuffer',
+			});
+		const apiResult = await retryWithExponentialBackoff(this.logger, apiCallFn);
 
 		if (!apiResult) {
 			return { json: {} };

--- a/nodes/Apify/resources/key-value-stores/get-key-value-store-record/execute.ts
+++ b/nodes/Apify/resources/key-value-stores/get-key-value-store-record/execute.ts
@@ -30,7 +30,7 @@ export async function getKeyValueStoreRecord(
 				returnFullResponse: true,
 				encoding: 'arraybuffer',
 			});
-		const apiResult = await retryWithExponentialBackoff(this.logger, apiCallFn);
+		const apiResult = await retryWithExponentialBackoff(apiCallFn);
 
 		if (!apiResult) {
 			return { json: {} };


### PR DESCRIPTION
- Wrapped api call function with exponential backoff function, which will retry calls that return either 429 - too many requests code or http 500+ codes.
- Added test for the exp backoff  