### PR TITLE
adhoc: improve input json description

### DIFF
--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/properties.ts
@@ -35,7 +35,7 @@ export const properties: INodeProperties[] = [
 		type: 'json',
 		default: '{}',
 		description:
-			'JSON input for the Actor run, which you can find on the Actor input page in Apify Console. If empty, the run uses the input specified in the default run configuration.',
+			'JSON input for the Actor run, which you can find on the Actor input page in Apify Console. If empty, the run uses the input specified in the default run configuration. https://console.apify.com',
 		displayOptions: {
 			show: {
 				resource: ['Actors'],

--- a/nodes/Apify/resources/actors/run-actor/properties.ts
+++ b/nodes/Apify/resources/actors/run-actor/properties.ts
@@ -35,7 +35,7 @@ export const properties: INodeProperties[] = [
 		type: 'json',
 		default: '{}',
 		description:
-			'JSON input for the Actor run, which you can find on the Actor input page in Apify Console. If empty, the run uses the input specified in the default run configuration.',
+			'JSON input for the Actor run, which you can find on the Actor input page in Apify Console. If empty, the run uses the input specified in the default run configuration. https://console.apify.com',
 		displayOptions: {
 			show: {
 				resource: ['Actors'],


### PR DESCRIPTION
Lukas B. suggested it would be nice for `input JSON` description to include a link to the console so users can copy and paste it.

<img width="1064" height="392" alt="Screenshot 2025-09-17 at 19 00 46" src="https://github.com/user-attachments/assets/c12edae6-6e0b-4c33-a38e-17ed2df722c3" />
