### PR TITLE
feat: Add fields and omit options to Get Dataset Items

### DIFF
--- a/nodes/Apify/resources/datasets/get-items/execute.ts
+++ b/nodes/Apify/resources/datasets/get-items/execute.ts
@@ -10,7 +10,7 @@ export async function getItems(this: IExecuteFunctions, i: number): Promise<INod
 	const datasetId = this.getNodeParameter('datasetId', i) as string;
 	const offset = this.getNodeParameter('offset', i, 0) as number;
 	const limit = this.getNodeParameter('limit', i, 50) as number;
-	const options = this.getNodeParameter('options', i, {}) as {
+	const options = (this.getNodeParameter('options', i, {}) || {}) as {
 		fields?: string;
 		omit?: string;
 	};

--- a/nodes/Apify/resources/datasets/get-items/execute.ts
+++ b/nodes/Apify/resources/datasets/get-items/execute.ts
@@ -10,16 +10,30 @@ export async function getItems(this: IExecuteFunctions, i: number): Promise<INod
 	const datasetId = this.getNodeParameter('datasetId', i) as string;
 	const offset = this.getNodeParameter('offset', i, 0) as number;
 	const limit = this.getNodeParameter('limit', i, 50) as number;
+	const options = this.getNodeParameter('options', i, {}) as {
+		fields?: string;
+		omit?: string;
+	};
 
 	if (!datasetId) {
 		throw new NodeOperationError(this.getNode(), 'Dataset ID is required');
+	}
+
+	const qs: { offset: number; limit: number; fields?: string; omit?: string } = { offset, limit };
+
+	if (options.fields) {
+		qs.fields = options.fields;
+	}
+
+	if (options.omit) {
+		qs.omit = options.omit;
 	}
 
 	try {
 		const itemsArray = await apiRequest.call(this, {
 			method: 'GET',
 			uri: `/v2/datasets/${datasetId}/items`,
-			qs: { offset, limit },
+			qs,
 		});
 
 		return this.helpers.returnJsonArray(itemsArray);

--- a/nodes/Apify/resources/datasets/get-items/execute.ts
+++ b/nodes/Apify/resources/datasets/get-items/execute.ts
@@ -6,6 +6,14 @@ import {
 } from 'n8n-workflow';
 import { apiRequest } from '../../../resources/genericFunctions';
 
+function normalizeCommaSeparatedList(value: string): string {
+	return value
+		.split(',')
+		.map((field) => field.trim())
+		.filter((field) => field.length > 0)
+		.join(',');
+}
+
 export async function getItems(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {
 	const datasetId = this.getNodeParameter('datasetId', i) as string;
 	const offset = this.getNodeParameter('offset', i, 0) as number;
@@ -22,11 +30,11 @@ export async function getItems(this: IExecuteFunctions, i: number): Promise<INod
 	const qs: { offset: number; limit: number; fields?: string; omit?: string } = { offset, limit };
 
 	if (options.fields) {
-		qs.fields = options.fields;
+		qs.fields = normalizeCommaSeparatedList(options.fields);
 	}
 
 	if (options.omit) {
-		qs.omit = options.omit;
+		qs.omit = normalizeCommaSeparatedList(options.omit);
 	}
 
 	try {

--- a/nodes/Apify/resources/datasets/get-items/properties.ts
+++ b/nodes/Apify/resources/datasets/get-items/properties.ts
@@ -44,4 +44,35 @@ export const properties: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['Datasets'],
+				operation: ['Get items'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Fields',
+				name: 'fields',
+				type: 'string',
+				default: '',
+				description:
+					'Comma-separated list of fields to include in the results. Only these fields will be returned.',
+			},
+			{
+				displayName: 'Omit',
+				name: 'omit',
+				type: 'string',
+				default: '',
+				description:
+					'Comma-separated list of fields to exclude from the results. If a field appears in both "fields" and "omit", it will be excluded.',
+			},
+		],
+	},
 ];


### PR DESCRIPTION
## Summary

- Added optional **Fields** and **Omit** parameters to the "Get Items" operation for datasets
- These parameters allow users to filter which columns are included or excluded from dataset results
- Implemented as an "Options" collection (click "Add Option" to reveal) for a clean UX that keeps the main interface simple

## Details

Based on the [Apify Dataset API documentation](https://docs.apify.com/platform/storage/dataset):

- **Fields**: Comma-separated list of fields to include in the results. Only these fields will be returned.
- **Omit**: Comma-separated list of fields to exclude from the results. If a field appears in both "fields" and "omit", it will be excluded (omit takes precedence).

## UX Design Choice

The new options are hidden by default and accessible via an "Add Option" button. This keeps the basic interface clean for simple use cases while providing power users with field filtering capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)