### PR TITLE
feat: enable npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js & cache npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,13 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout code
@@ -18,10 +20,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js & cache npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
+
+      - name: Ensure npm >= 11.5.1
+        run: npm install -g "npm@^11.5.1"
 
       - name: Install dependencies
         run: npm ci
@@ -64,12 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      - name: Set up npm for publishing
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}" > .npmrc
-
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
         run: |
           if npm view @apify/n8n-nodes-apify@${{ env.VERSION }} version > /dev/null 2>&1; then
             echo "Version ${{ env.VERSION }} of @apify/n8n-nodes-apify is already published to npm. Skipping publish step."


### PR DESCRIPTION
## Summary
- Enables npm trusted publishing using GitHub OIDC (no more npm tokens needed)
- Adds `id-token: write` permission for OIDC authentication
- Updates `actions/setup-node` to v6 with registry-url configuration
- Adds npm version upgrade step (requires >= 11.5.1 for provenance support)
- Removes manual npm token authentication (`.npmrc` creation and `NODE_AUTH_TOKEN` env var)

## Test plan
- [x] Verify CI workflow still passes
- [x] Create a test release to verify npm publish works with trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)